### PR TITLE
Improvements in block command and new config options available. (v2.0.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+# [ unreleased ]
+
+Improvements in commands and new config option available.
+
+### Added 
+- Added the ability to use your own log channel 
+    - You can do this by using the `config set log_channel_id <id>` command.
+
+### Changed
+- You now have the ability to supply a reason when blocking a user. 
+- Blocked users are now stored in the database instead of in the channel topic.
+- This means you can delete the top channel in the modmail category now.
+
+
 # v2.0.7
 
 New command and improvements in bot update message interfaces. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-# [ unreleased ]
+# v2.0.8
 
-Improvements in commands and new config option available.
+Improvements in commands and new config options available.
 
 ### Added 
 - Added the ability to use your own log channel 
-    - You can do this by using the `config set log_channel_id <id>` command.
+    - You can do this via the `config set log_channel_id <id>` command.
+- Added the ability to use your own main inbox category.
+    - You can do this via the `config set main_category_id <id>` command.
 
 ### Changed
 - You now have the ability to supply a reason when blocking a user. 
 - Blocked users are now stored in the database instead of in the channel topic.
-- This means you can delete the top channel in the modmail category now.
-
+    - This means you can delete the top channel in the modmail category now. (Migrate first though.)
 
 # v2.0.7
 

--- a/bot.py
+++ b/bot.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-__version__ = '2.0.7'
+__version__ = '2.0.8'
 
 import asyncio
 import textwrap
@@ -94,7 +94,7 @@ class ModmailBot(commands.Bot):
         
     @property
     def log_channel(self):
-        channel_id = self.config.get('bot_log_channel_id')
+        channel_id = self.config.get('log_channel_id')
         if channel_id is not None:
             return self.get_channel(int(channel_id))
         else:
@@ -136,14 +136,15 @@ class ModmailBot(commands.Bot):
 
     @property
     def main_category(self):
+        category_id = self.config.get('main_category_id')
+        if category_id is not None:
+            return discord.utils.get(self.modmail_guild.categories, id=int(category_id))
         if self.modmail_guild:
             return discord.utils.get(self.modmail_guild.categories, name='Mod Mail')
 
     @property
     def blocked_users(self):
-        if self.modmail_guild:
-            top_chan = self.main_category.channels[0]
-            return [int(i) for i in re.findall(r'\d+', top_chan.topic)]
+        return self.config.get('blocked', {})
 
     @property
     def prefix(self):
@@ -422,7 +423,7 @@ class ModmailBot(commands.Bot):
                     short_sha = commit_data['sha'][:6]
                     em.add_field(name='Merge Commit', value=f"[`{short_sha}`]({html_url}) {message} - {user['username']}")
                     print('Updating bot.')
-                    channel = self.main_category.channels[0]
+                    channel = self.log_channel
                     await channel.send(embed=em)
 
             await asyncio.sleep(3600)

--- a/bot.py
+++ b/bot.py
@@ -91,6 +91,14 @@ class ModmailBot(commands.Bot):
             super().run(self.token)
         finally:
             print(Fore.RED + ' - Shutting down bot' + Style.RESET_ALL)
+        
+    @property
+    def log_channel(self):
+        channel_id = self.config.get('bot_log_channel_id')
+        if channel_id is not None:
+            return self.get_channel(int(channel_id))
+        else:
+            return self.main_category.channels[0]
 
     @property
     def snippets(self):
@@ -167,7 +175,7 @@ class ModmailBot(commands.Bot):
         {Fore.CYAN}Guild ID: {self.guild.id if self.guild else 0}
         {line}
         """).strip())
-        
+
         if not self.guild:
             print(Fore.RED + Style.BRIGHT + 'WARNING - The GUILD_ID provided does not exist!' + Style.RESET_ALL)
         else:
@@ -292,7 +300,7 @@ class ModmailBot(commands.Bot):
             desc = f"[`{log_data['key']}`]({log_url}) {mod.mention} closed a thread with {user}"
             em = discord.Embed(description=desc, color=em.color)
             em.set_author(name='Thread closed', url=log_url)
-            await self.main_category.channels[0].send(embed=em)
+            await self.log_channel.send(embed=em)
 
     async def on_message_delete(self, message):
         """Support for deleting linked messages"""

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -138,8 +138,7 @@ class Modmail:
             pass
 
         # Logging
-        categ = self.bot.main_category
-        log_channel = categ.channels[0]
+        log_channel = self.bot.log_channel
 
         log_data = await self.bot.modmail_api.post_log(ctx.channel.id, {
             'open': False, 'closed_at': str(datetime.datetime.utcnow()), 'closer': {

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -87,9 +87,6 @@ class Modmail:
     async def __del(self, ctx, *, name: str.lower):
         """Removes a snippet from bot config."""
 
-        if 'snippets' not in self.bot.config.cache:
-            self.bot.config['snippets'] = {}
-
         em = discord.Embed(
             title='Removed snippet',
             color=discord.Color.green(),
@@ -101,7 +98,7 @@ class Modmail:
             em.color = discord.Color.red()
             em.description = f'Snippet `{name}` does not exist.'
         else:
-            self.bot.config['snippets'][name] = None
+            del self.bot.config['snippets'][name]
             await self.bot.config.update()
 
         await ctx.send(embed=em)

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -392,7 +392,7 @@ class Utility:
             valid_keys = [f'`{k}`' for k in self.bot.config.allowed_to_change_in_command]
             em.add_field(name='Valid keys', value=', '.join(valid_keys))
         else:
-            self.bot.config.cache[key] = None
+            del self.bot.config.cache[key]
             await self.bot.config.update()
 
         await ctx.send(embed=em)
@@ -498,7 +498,7 @@ class Utility:
             em.color = discord.Color.red()
             em.description = f'Alias `{name}` does not exist.'
         else:
-            self.bot.config['aliases'][name] = None
+            del self.bot.config['aliases'][name]
             await self.bot.config.update()
 
         await ctx.send(embed=em)

--- a/core/config.py
+++ b/core/config.py
@@ -7,7 +7,8 @@ class ConfigManager:
     """Class that manages a cached configuration"""
 
     allowed_to_change_in_command = {
-        'status', 'bot_log_channel_id', 'mention', 'disable_autoupdates', 'prefix'
+        'status', 'log_channel_id', 'mention', 'disable_autoupdates', 'prefix',
+        'main_category_id'
         }
     
     internal_keys = {
@@ -28,10 +29,15 @@ class ConfigManager:
         return self.bot.modmail_api
 
     def populate_cache(self):
+        data = {
+            'snippets': {},
+            'aliases': {},
+            'blocked': {}
+        }
         try:
-            data = json.load(open('config.json'))
+            data.update(json.load(open('config.json')))
         except FileNotFoundError:
-            data = {}
+            pass
         finally:
             data.update(os.environ)
             data = {k.lower(): v for k, v in data.items() if k.lower() in self.valid_keys}

--- a/core/config.py
+++ b/core/config.py
@@ -6,14 +6,16 @@ import box
 class ConfigManager:
     """Class that manages a cached configuration"""
 
-    valid_keys = {
-        'prefix', 'status', 'guild_id',
-        'mention', 'disable_autoupdates',
-        'modmail_guild_id', 'token', 'snippets',
-        'aliases', 'owners', 'modmail_api_token'
-    }
+    allowed_to_change_in_command = {
+        'status', 'bot_log_channel_id', 'mention', 'disable_autoupdates', 'prefix'
+        }
+    
+    internal_keys = {
+        'token', 'snippets', 'aliases', 'owners', 'modmail_api_token',
+        'guild_id', 'modmail_guild_id', 'blocked'
+        }
 
-    allowed_to_change_in_command = valid_keys - {'token', 'snippets', 'aliases', 'owners', 'modmail_api_token'}
+    valid_keys = allowed_to_change_in_command.union(internal_keys)
 
     def __init__(self, bot):
         self.bot = bot


### PR DESCRIPTION
### Added 
- Added the ability to use your own log channel 
    - You can do this via the `config set log_channel_id <id>` command.
- Added the ability to use your own main inbox category.
    - You can do this via the `config set main_category_id <id>` command.

### Changed
- You now have the ability to supply a reason when blocking a user. 
- Blocked users are now stored in the database instead of in the channel topic.
    - This means you can delete the top channel in the modmail category now. (Migrate first though.)
