### PR TITLE
Allow for "Custom response message for thread creation"

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -8,7 +8,7 @@ class ConfigManager:
 
     allowed_to_change_in_command = {
         'status', 'log_channel_id', 'mention', 'disable_autoupdates', 'prefix',
-        'main_category_id', 'sent_emoji', 'blocked_emoji'
+        'main_category_id', 'sent_emoji', 'blocked_emoji', 'response_thread_created'
         }
     
     internal_keys = {

--- a/core/thread.py
+++ b/core/thread.py
@@ -225,7 +225,7 @@ class ThreadManager:
 
         em = discord.Embed(
             title='Thread started' if creator else 'Thanks for the message!',
-            description='The moderation team will get back to you as soon as possible!',
+            description=self.bot.config.get('response_thread_created', 'The moderation team will get back to you as soon as possible!'),
             color=discord.Color.green()
         )
 


### PR DESCRIPTION
The configuration variable name is kind of weird, no clue if that should be changed. I don't know if I used self.bot.config.get() correct either but based on the code it takes in 2 parameters for the configuration variable to get, and if that configuration variable isn't set it picks a default or the 2nd parameter.