### PR TITLE
Add ability to selfhost logs 

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 worker: python bot.py
+web: python app.py

--- a/app.py
+++ b/app.py
@@ -14,11 +14,11 @@ async def init(app, loop):
 
 @app.get('/')
 async def index(request):
-    return response.text('Welcome! This simple webserver is used to display your modmail logs.')
+    return response.text('Welcome! This simple website is used to display your modmail logs.')
 
 @app.get('/logs/<key>')
 async def getlogsfile(request, key):
-    '''Returned the plain text rendered log entry'''
+    """Returned the plain text rendered log entry"""
 
     log = await app.db.logs.find_one({'key': key})
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,29 @@
+import os 
+
+from sanic import Sanic, response
+from motor.motor_asyncio import AsyncIOMotorClient
+import aiohttp
+
+from core.models import LogEntry 
+
+app = Sanic(__name__)
+
+@app.listener('before_server_start')
+async def init(app, loop):
+    app.db = AsyncIOMotorClient(os.getenv('MONGO_URI')).modmail
+
+app.get('/')
+async def index(request):
+    return response.json('Welcome!')
+
+@app.get('/<key>')
+async def getlogsfile(request, key):
+    log = await app.db.logs.find_one({'key': key})
+
+    if log is None:
+        return response.text('Not Found', status=404)
+    else:
+        return response.text(str(LogEntry(log)))
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=os.getenv('PORT'))

--- a/app.py
+++ b/app.py
@@ -10,14 +10,16 @@ app = Sanic(__name__)
 
 @app.listener('before_server_start')
 async def init(app, loop):
-    app.db = AsyncIOMotorClient(os.getenv('MONGO_URI')).modmail
+    app.db = AsyncIOMotorClient(os.getenv('MONGO_URI')).modmail_bot
 
-app.get('/')
+@app.get('/')
 async def index(request):
-    return response.json('Welcome!')
+    return response.text('Welcome! This simple webserver is used to display your modmail logs.')
 
-@app.get('/<key>')
+@app.get('/logs/<key>')
 async def getlogsfile(request, key):
+    print(key)
+
     log = await app.db.logs.find_one({'key': key})
 
     if log is None:

--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ async def index(request):
 
 @app.get('/logs/<key>')
 async def getlogsfile(request, key):
-    print(key)
+    '''Returned the plain text rendered log entry'''
 
     log = await app.db.logs.find_one({'key': key})
 

--- a/bot.py
+++ b/bot.py
@@ -163,13 +163,16 @@ class ModmailBot(commands.Bot):
         return [bot.prefix, f'<@{bot.user.id}> ', f'<@!{bot.user.id}> ']
 
     async def on_connect(self):
-        print(line + Fore.RED + Style.BRIGHT)
+        print(line)
+        print(Fore.CYAN, end='')
         if not self.selfhosted:
-            print('Mode: using api.modmail.tk')
+            print('MODE: Using the Modmail API')
+            print(line)
             await self.validate_api_token()
             print(line)
         else:
-            print('Mode: selfhosting logs.')
+            print('Mode: Selfhosting logs.')
+            print(line)
         print(Fore.CYAN + 'Connected to gateway.')
         await self.config.refresh()
         status = self.config.get('status')
@@ -364,12 +367,16 @@ class ModmailBot(commands.Bot):
         try:
             self.config.modmail_api_token
         except KeyError:
+            print(Fore.RED + Style.BRIGHT, end='')
             print('MODMAIL_API_TOKEN not found.')
             print('Set a config variable called MODMAIL_API_TOKEN with a token from https://dashboard.modmail.tk')
+            print('If you want to selfhost logs, input a MONGO_URI config variable.')
+            print('A modmail api token is not needed if you are selfhosting logs.')
             valid = False
         else:
             valid = await self.modmail_api.validate_token()
             if not valid:
+                print(Fore.RED + Style.BRIGHT, end='')
                 print('Invalid MODMAIL_API_TOKEN - get one from https://dashboard.modmail.tk')
         finally:
             if not valid:

--- a/bot.py
+++ b/bot.py
@@ -38,7 +38,7 @@ from discord.ext.commands.view import StringView
 from colorama import init, Fore, Style
 import emoji
 
-from core.api import Github, ModmailApiClient
+from core.interfaces import Github, ModmailApiClient, SelfhostedApiInterface
 from core.thread import ThreadManager
 from core.config import ConfigManager
 from core.changelog import ChangeLog

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -343,9 +343,9 @@ class Modmail:
             time = date.strftime(r'%H:%M')
 
             key = entry['key']
-            user_id = entry['user_id']
+            user_id = entry.get('user_id')
             closer = entry['closer']['name']
-            log_url = f"https://logs.modmail.tk/{user_id}/{key}"
+            log_url = f"https://logs.modmail.tk/{user_id}/{key}" if not self.bot.selfhosted else self.bot.config.log_url + f'/logs/{key}'
 
             truncate = lambda c: c[:47].strip() + '...' if len(c) > 50 else c
 

--- a/core/config.py
+++ b/core/config.py
@@ -17,7 +17,7 @@ class ConfigManager:
     
     protected_keys = {
         'token', 'owners', 'modmail_api_token', 'guild_id', 'modmail_guild_id', 
-        'mongo_uri', 'github_access_token', 'log_domain'
+        'mongo_uri', 'github_access_token', 'log_url'
         }
 
     valid_keys = allowed_to_change_in_command.union(internal_keys).union(protected_keys)
@@ -49,8 +49,6 @@ class ConfigManager:
             data.update(os.environ)
             data = {k.lower(): v for k, v in data.items() if k.lower() in self.valid_keys}
             self.cache = data
-
-        self.bot.loop.create_task(self.refresh())
 
     async def update(self, data=None):
         """Updates the config with data from the cache"""

--- a/core/config.py
+++ b/core/config.py
@@ -16,7 +16,8 @@ class ConfigManager:
         }
     
     protected_keys = {
-        'token', 'owners', 'modmail_api_token', 'guild_id', 'modmail_guild_id',
+        'token', 'owners', 'modmail_api_token', 'guild_id', 'modmail_guild_id', 
+        'mongo_uri', 'github_access_token', 'log_domain'
         }
 
     valid_keys = allowed_to_change_in_command.union(internal_keys).union(protected_keys)

--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -117,3 +117,11 @@ class ModmailApiClient(ApiClient):
 
     def post_log(self, channel_id, payload):
         return self.request(self.logs + f'/{channel_id}', method='POST', payload=payload)
+
+
+class SelfhostedApiInterface(ModmailApiClient):
+    @property
+    def db(self)
+        return self.bot.db 
+
+

--- a/core/models.py
+++ b/core/models.py
@@ -1,0 +1,74 @@
+from datetime import datetime
+import dateutil.parser
+
+class LogEntry:
+    def __init__(self, data):
+        self.key = data['key']
+        self.open = data['open']
+        self.created_at = dateutil.parser.parse(data['created_at'])
+        self.closed_at = dateutil.parser.parse(data['closed_at']) if not self.open else None
+        self.channel_id = int(data['channel_id'])
+        self.guild_id = int(data['guild_id'])
+        self.creator = User(data['creator'])
+        self.recipient = User(data['recipient'])
+        self.closer = User(data['closer']) if not self.open else None
+        self.messages = [Message(m) for m in data['messages']]
+
+    def __str__(self):
+        out = f"Thread created at {self.created_at.strftime('%d %b %Y - %H:%M UTC')}\n"
+
+        if self.creator == self.recipient:
+            out += f'[R] {self.creator} ({self.creator.id}) created a modmail thread. \n'
+        else:
+            out += f'[M] {self.creator} created a thread with [R] {self.recipient} ({self.recipient.id})\n'
+        
+        out += '────────────────' * 3 + '\n'
+
+        if self.messages:
+            for index, message in enumerate(self.messages):
+                next_index = index + 1 if index + 1 < len(self.messages) else index
+                curr, next = message.author, self.messages[next_index].author 
+
+                author = curr
+                base = message.created_at.strftime('%d/%m %H:%M') + (' [M] ' if author.mod else ' [R] ')
+                base += f'{author}: {message.content}\n'
+                for attachment in message.attachments:
+                    base += 'Attachment: ' + attachment + '\n'
+                    
+                out += base
+
+                if curr != next:
+                    out += '────────────────' * 2 + '\n'
+                    current_author = author
+
+        if not self.open:
+            if self.messages:  # only add if at least 1 message was sent
+                out += '────────────────' * 3 + '\n'            
+            out += f'[M] {self.closer} ({self.closer.id}) closed the modmail thread. \n'
+            out += f"Thread closed at {self.closed_at.strftime('%d %b %Y - %H:%M UTC')} \n"
+                    
+        return out
+
+
+class User:
+    def __init__(self, data):
+        self.id = int(data.get('id'))
+        self.name = data['name']
+        self.discriminator = data['discriminator']
+        self.avatar_url = data['avatar_url']
+        self.mod = data['mod']
+    
+    def __str__(self):
+        return f'{self.name}#{self.discriminator}'
+    
+    def __eq__(self, other):
+        return self.id == other.id and self.mod is other.mod
+
+
+class Message:
+    def __init__(self, data):
+        self.id = int(data['message_id'])
+        self.created_at = dateutil.parser.parse(data['timestamp'])
+        self.content = data['content']
+        self.attachments = data['attachments']
+        self.author = User(data['author'])

--- a/core/thread.py
+++ b/core/thread.py
@@ -73,7 +73,11 @@ class Thread:
         if isinstance(log_data, str):
             print(log_data) # errored somehow on server
 
-        log_url = f"https://logs.modmail.tk/{log_data['user_id']}/{log_data['key']}"
+        if self.bot.selfhosted:
+            log_url = f'{self.bot.config.log_url}/logs/{log_data["key"]}'
+        else:
+            log_url = f"https://logs.modmail.tk/{log_data['user_id']}/{log_data['key']}" 
+
         user = self.recipient.mention if self.recipient else f'`{self.id}`'
 
         if log_data['messages']:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ emoji
 dhooks
 natural
 parsedatetime
+motor
+sanic

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ natural
 parsedatetime
 motor
 sanic
+dnspython


### PR DESCRIPTION
This pr implements a separate mode in the bot which makes it able to store logs in a user-owned database. A mongodb cluster uri needs to be inputted for this mode to be enabled. 

To enable this mode you need to add the following config variables on Heroku.
`MONGO_URI` - The mongodb cluster connection URI 
`LOG_URL` - The URL of your Heroku app. e.g. `https://yourappname.herokuapp.com`

You will also need to turn on the web worker. 