### PR TITLE
Added `activity` command for Issue #116

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,12 @@ ENV/
 # mypy
 .mypy_cache/
 *.json
+!app.json
 
+#Pycharm
+.idea/
+
+#MacOs
+.DS_Store
 
 config.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-# v2.3.1
+# v2.4.0
+
+Breaking changes for bot status.
 
 ### Added 
 - Added the `activity` command for setting the activity
-- [PR #131](https://github.com/kyb3r/modmail/pull/131#issue-244686818)
+- [PR #131](https://github.com/kyb3r/modmail/pull/131#issue-244686818) this supports multiple activity types (playing, watching, listening and streaming).
 
 ### Removed
 - Removed the deprecated `status` command. 
+- This also means you will have to reset your bot status with the `activity` command as it will break. 
 
 # v2.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+# v2.3.1
+
+### Added 
+- Added the `activity` command for setting the activity
+- [PR #131](https://github.com/kyb3r/modmail/pull/131#issue-244686818)
+
+### Removed
+- Removed the deprecated `status` command. 
+
 # v2.3.0
 
 ### Added 

--- a/bot.py
+++ b/bot.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-__version__ = '2.3.0'
+__version__ = '2.3.1'
 
 import asyncio
 import textwrap
@@ -33,6 +33,7 @@ from types import SimpleNamespace
 
 import discord
 import aiohttp
+from discord.enums import ActivityType
 from discord.ext import commands
 from discord.ext.commands.view import StringView
 from motor.motor_asyncio import AsyncIOMotorClient
@@ -179,7 +180,9 @@ class ModmailBot(commands.Bot):
         activity_type = self.config.get('activity_type')
         message = self.config.get('activity_message')
         if activity_type and message:
-            activity = discord.Activity(type=activity_type, name=message)
+            url = 'https://www.twitch.tv/discord-modmail/' if activity_type == ActivityType.streaming else None
+            activity = discord.Activity(type=activity_type, name=message,
+                                        url=url)
             await self.change_presence(activity=activity)
 
     async def on_ready(self):

--- a/bot.py
+++ b/bot.py
@@ -175,9 +175,12 @@ class ModmailBot(commands.Bot):
             print(line)
         print(Fore.CYAN + 'Connected to gateway.')
         await self.config.refresh()
-        status = self.config.get('status')
-        if status:
-            await self.change_presence(activity=discord.Game(status))
+
+        activity_type = self.config.get('activity_type')
+        message = self.config.get('activity_message')
+        if activity_type and message:
+            activity = discord.Activity(type=activity_type, name=message)
+            await self.change_presence(activity=activity)
 
     async def on_ready(self):
         """Bot startup, sets uptime."""

--- a/bot.py
+++ b/bot.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-__version__ = '2.3.1'
+__version__ = '2.4.0'
 
 import asyncio
 import textwrap

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -5,7 +5,6 @@ from typing import Optional, Union
 
 import discord
 from discord.ext import commands
-from discord.enums import ActivityType
 
 import dateutil.parser
 
@@ -124,19 +123,6 @@ class Modmail:
 
         await thread.channel.edit(category=category)
         await ctx.message.add_reaction('✅')
-
-    @commands.command()
-    async def status(self, ctx, activity_type: str, *, message: str):
-        activity_type = ActivityType[activity_type]
-        self.bot: commands.Bot
-        activity = discord.Activity(type=activity_type, name=message)
-        await self.bot.change_presence(activity=activity)
-        em = discord.Embed(
-            title='Status Changed',
-            description=f'{ActivityType(activity_type)}: {message}.',
-            color=discord.Color.green()
-        )
-        await ctx.send(embed=em)
 
     async def send_scheduled_close_message(self, ctx, after, silent=False):
         human_delta = human_timedelta(after.dt)

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -2,10 +2,11 @@
 
 import datetime
 from typing import Optional, Union
-import re 
 
 import discord
 from discord.ext import commands
+from discord.enums import ActivityType
+
 import dateutil.parser
 
 from core.decorators import trigger_typing
@@ -123,6 +124,19 @@ class Modmail:
 
         await thread.channel.edit(category=category)
         await ctx.message.add_reaction('✅')
+
+    @commands.command()
+    async def status(self, ctx, activity_type: str, *, message: str):
+        activity_type = ActivityType[activity_type]
+        self.bot: commands.Bot
+        activity = discord.Activity(type=activity_type, name=message)
+        await self.bot.change_presence(activity=activity)
+        em = discord.Embed(
+            title='Status Changed',
+            description=f'{ActivityType(activity_type)}: {message}.',
+            color=discord.Color.green()
+        )
+        await ctx.send(embed=em)
 
     async def send_scheduled_close_message(self, ctx, after, silent=False):
         human_delta = human_timedelta(after.dt)

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -267,28 +267,47 @@ class Utility:
             else:
                 em.description = 'Already up to date with master repository.'
 
-            
         await ctx.send(embed=em)
 
     @commands.command(aliases=['presence'])
     @commands.has_permissions(administrator=True)
-    async def status(self, ctx, activity_type: str, *, message: str = ''):
+    async def activity(self, ctx, activity_type: str, *, message: str = ''):
         """
-        Set a custom playing status for the bot.
+        Set a custom activity for the bot.
 
-        [prefix]status activity message...
+        Possible activity types: `playing`, `streaming`, `listening`, `watching`, `clear`
 
-        Set the message to `clear` if you want to remove the status.
+        When activity type is set to `clear`, the current activity is removed.
         """
         if activity_type == 'clear':
             await self.bot.change_presence(activity=None)
             self.bot.config['activity_type'] = None
             self.bot.config['activity_message'] = None
             await self.bot.config.update()
-            return
+            em = discord.Embed(
+                title='Activity Removed',
+                color=discord.Color.green()
+            )
+            return await ctx.send(embed=em)
 
-        activity_type = ActivityType[activity_type]
-        self.bot: commands.Bot
+        if not message:
+            em = discord.Embed(
+                title='Invalid Message',
+                description='You must set an activity message.',
+                color=discord.Color.red()
+            )
+            return await ctx.send(embed=em)
+
+        try:
+            activity_type = ActivityType[activity_type]
+        except KeyError:
+            em = discord.Embed(
+                title='Invalid Activity Type',
+                description=f'Cannot set activity to: {activity_type}.',
+                color=discord.Color.red()
+            )
+            return await ctx.send(embed=em)
+
         activity = discord.Activity(type=activity_type, name=message)
         await self.bot.change_presence(activity=activity)
         self.bot.config['activity_type'] = activity_type
@@ -296,11 +315,11 @@ class Utility:
         await self.bot.config.update()
 
         em = discord.Embed(
-            title='Status Changed',
-            description=f'{ActivityType(activity_type)}: {message}.',
+            title='Activity Changed',
+            description=f'Current activity is: {activity_type.name} {message}.',
             color=discord.Color.green()
         )
-        await ctx.send(embed=em)
+        return await ctx.send(embed=em)
 
     @commands.command()
     @trigger_typing

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -291,22 +291,12 @@ class Utility:
             return await ctx.send(embed=em)
 
         if not message:
-            em = discord.Embed(
-                title='Invalid Message',
-                description='You must set an activity message.',
-                color=discord.Color.red()
-            )
-            return await ctx.send(embed=em)
+            raise commands.UserInputError
 
         try:
             activity_type = ActivityType[activity_type]
         except KeyError:
-            em = discord.Embed(
-                title='Invalid Activity Type',
-                description=f'Cannot set activity to: {activity_type}.',
-                color=discord.Color.red()
-            )
-            return await ctx.send(embed=em)
+            raise commands.UserInputError
 
         url = 'https://www.twitch.tv/discord-modmail/' if activity_type == ActivityType.streaming else None
         activity = discord.Activity(type=activity_type, name=message, url=url)

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -1,5 +1,7 @@
 import discord
 from discord.ext import commands
+from discord.enums import ActivityType
+
 import datetime
 import traceback
 import inspect
@@ -268,26 +270,36 @@ class Utility:
             
         await ctx.send(embed=em)
 
-    @commands.command(name='status', aliases=['customstatus', 'presence'])
+    @commands.command(aliases=['presence'])
     @commands.has_permissions(administrator=True)
-    async def _status(self, ctx, *, message):
-        """Set a custom playing status for the bot.
-
-        Set the message to `clear` if you want to remove the playing status.
+    async def status(self, ctx, activity_type: str, *, message: str = ''):
         """
+        Set a custom playing status for the bot.
 
-        if message == 'clear':
-            self.bot.config['status'] = None
+        [prefix]status activity message...
+
+        Set the message to `clear` if you want to remove the status.
+        """
+        if activity_type == 'clear':
+            await self.bot.change_presence(activity=None)
+            self.bot.config['activity_type'] = None
+            self.bot.config['activity_message'] = None
             await self.bot.config.update()
-            return await self.bot.change_presence(activity=None)
+            return
 
-        await self.bot.change_presence(activity=discord.Game(message))
-        self.bot.config['status'] = message
+        activity_type = ActivityType[activity_type]
+        self.bot: commands.Bot
+        activity = discord.Activity(type=activity_type, name=message)
+        await self.bot.change_presence(activity=activity)
+        self.bot.config['activity_type'] = activity_type
+        self.bot.config['activity_message'] = message
         await self.bot.config.update()
 
-        em = discord.Embed(title='Status Changed')
-        em.description = message
-        em.color = discord.Color.green()
+        em = discord.Embed(
+            title='Status Changed',
+            description=f'{ActivityType(activity_type)}: {message}.',
+            color=discord.Color.green()
+        )
         await ctx.send(embed=em)
 
     @commands.command()

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -308,7 +308,8 @@ class Utility:
             )
             return await ctx.send(embed=em)
 
-        activity = discord.Activity(type=activity_type, name=message)
+        url = 'https://www.twitch.tv/discord-modmail/' if activity_type == ActivityType.streaming else None
+        activity = discord.Activity(type=activity_type, name=message, url=url)
         await self.bot.change_presence(activity=activity)
         self.bot.config['activity_type'] = activity_type
         self.bot.config['activity_message'] = message


### PR DESCRIPTION
Fixes #116 

Added an `activity` command for setting the activity of ModMail, usage:

  - `[prefix]activity activity_type [message...]`
  - `[prefix]presence  activity_type [message...]`

Activity types can be: `playing`, `streaming`, `listening`, `watching`, or `clear`.
If activity type is `clear`, the current activity is removed, and no `message` is required.

## Notes:

  - Did **not** use `status` as the command name since discord rewrite reserves "status" for the state of the bot. Ie `online`, `offline`, `idle`, `dnd`, and `invisible`.
  - Slightly updated `.gitignore` 