### PR TITLE
Scheduled close event for thread save to config vars

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -204,6 +204,7 @@ class ModmailBot(commands.Bot):
             await self.threads.populate_cache()
 
         closures = self.config.get('closures', {})
+        print(closures)  # for debugging
         for recipient_id, items in closures.items():
             after = (datetime.datetime.fromisoformat(items['time']) -
                      datetime.datetime.utcnow()).total_seconds()

--- a/bot.py
+++ b/bot.py
@@ -203,7 +203,21 @@ class ModmailBot(commands.Bot):
         else:
             await self.threads.populate_cache()
 
+        closures = self.config.get('closures', {})
+        for recipient_id, items in closures.items():
+            after = (datetime.datetime.fromisoformat(items['time']) -
+                     datetime.datetime.utcnow()).total_seconds()
+            if after < 0:
+                after = 0
+            thread = await self.threads.find(
+                recipient=self.get_user(recipient_id))
 
+            # TODO: Retrieve messages/replies when bot is down, from history?
+            await thread.close(closer=self.get_user(items['closer_id']),
+                               after=after,
+                               silent=items['silent'],
+                               delete_channel=items['delete_channel'],
+                               message=items['message'])
 
     async def process_modmail(self, message):
         """Processes messages sent to the bot."""

--- a/bot.py
+++ b/bot.py
@@ -202,6 +202,7 @@ class ModmailBot(commands.Bot):
             print(Fore.RED + Style.BRIGHT + 'WARNING - The GUILD_ID provided does not exist!' + Style.RESET_ALL)
         else:
             await self.threads.populate_cache()
+        await self.config.update()
 
         closures = self.config.get('closures', {})
         print(closures)  # for debugging

--- a/bot.py
+++ b/bot.py
@@ -211,7 +211,7 @@ class ModmailBot(commands.Bot):
                      datetime.datetime.utcnow()).total_seconds()
             if after < 0:
                 after = 0
-            recipient = self.get_user(recipient_id)
+            recipient = self.get_user(int(recipient_id))
             print(recipient)
             thread = await self.threads.find(
                 recipient=recipient)

--- a/bot.py
+++ b/bot.py
@@ -211,9 +211,11 @@ class ModmailBot(commands.Bot):
                      datetime.datetime.utcnow()).total_seconds()
             if after < 0:
                 after = 0
+            recipient = self.get_user(recipient_id)
+            print(recipient)
             thread = await self.threads.find(
-                recipient=self.get_user(recipient_id))
-
+                recipient=recipient)
+            print(thread)
             # TODO: Retrieve messages/replies when bot is down, from history?
             await thread.close(closer=self.get_user(items['closer_id']),
                                after=after,

--- a/core/config.py
+++ b/core/config.py
@@ -7,8 +7,10 @@ class ConfigManager:
     """Class that manages a cached configuration"""
 
     allowed_to_change_in_command = {
-        'activity_message', 'activity_type', 'log_channel_id', 'mention', 'disable_autoupdates', 'prefix',
-        'main_category_id', 'sent_emoji', 'blocked_emoji', 'thread_creation_response', 'twitch_url'
+        'activity_message', 'activity_type', 'log_channel_id',
+        'mention', 'disable_autoupdates', 'prefix',
+        'main_category_id', 'sent_emoji', 'blocked_emoji',
+        'thread_creation_response', 'twitch_url'
         }
     
     internal_keys = {
@@ -20,7 +22,7 @@ class ConfigManager:
         'mongo_uri', 'github_access_token', 'log_url'
         }
 
-    valid_keys = allowed_to_change_in_command.union(internal_keys).union(protected_keys)
+    valid_keys = allowed_to_change_in_command | internal_keys | protected_keys
 
     def __init__(self, bot):
         self.bot = bot
@@ -47,7 +49,8 @@ class ConfigManager:
             pass
         finally:
             data.update(os.environ)
-            data = {k.lower(): v for k, v in data.items() if k.lower() in self.valid_keys}
+            data = {k.lower(): v for k, v in data.items()
+                    if k.lower() in self.valid_keys}
             self.cache = data
 
     async def update(self, data=None):

--- a/core/config.py
+++ b/core/config.py
@@ -43,7 +43,6 @@ class ConfigManager:
             'blocked': {},
             'notification_squad': {},
             'subscriptions': {},
-            'closures': {}
         }
 
         try:

--- a/core/config.py
+++ b/core/config.py
@@ -14,7 +14,9 @@ class ConfigManager:
         }
     
     internal_keys = {
-        'snippets', 'aliases', 'blocked', 'notification_squad', 'subscriptions'
+        'snippets', 'aliases', 'blocked',
+        'notification_squad', 'subscriptions',
+        'closures'
         }
     
     protected_keys = {

--- a/core/config.py
+++ b/core/config.py
@@ -42,7 +42,8 @@ class ConfigManager:
             'aliases': {},
             'blocked': {},
             'notification_squad': {},
-            'subscriptions': {}
+            'subscriptions': {},
+            'closures': {}
         }
 
         try:

--- a/core/thread.py
+++ b/core/thread.py
@@ -53,6 +53,7 @@ class Thread:
         if self.close_task is not None:
             # restarts the after timer
             self.close_task.cancel()
+            self.close_task = None
 
         if after > 0:
             # TODO: Add somewhere to clean up broken closures
@@ -184,6 +185,7 @@ class Thread:
         if self.close_task is not None:
             # cancel closing if a thread message is sent.
             self.close_task.cancel()
+            self.close_task = None
             tasks.append(self.channel.send(
                 embed=discord.Embed(color=discord.Color.red(),
                                     description='Scheduled close has '
@@ -195,6 +197,7 @@ class Thread:
         if self.close_task is not None:
             # cancel closing if a thread message is sent.
             self.close_task.cancel()
+            self.close_task = None
             await self.channel.send(embed=discord.Embed(
                 color=discord.Color.red(),
                 description='Scheduled close has been cancelled.'))

--- a/core/thread.py
+++ b/core/thread.py
@@ -51,6 +51,7 @@ class Thread:
         """Close a thread now or after a set time in seconds"""
 
         if self.close_task is not None:
+            # restarts the after timer
             self.close_task.cancel()
 
         if after > 0:
@@ -164,7 +165,7 @@ class Thread:
             self.send(message, self.recipient, from_mod=True)
             ]
 
-        if self.close_task is not None and not self.close_task.cancelled():
+        if self.close_task is not None:
             # cancel closing if a thread message is sent.
             self.close_task.cancel()
             tasks.append(self.channel.send(
@@ -175,7 +176,7 @@ class Thread:
         await asyncio.gather(*tasks)
 
     async def send(self, message, destination=None, from_mod=False):
-        if self.close_task is not None and not self.close_task.cancelled():
+        if self.close_task is not None:
             # cancel closing if a thread message is sent.
             self.close_task.cancel()
             await self.channel.send(embed=discord.Embed(
@@ -282,7 +283,7 @@ class Thread:
         if key in config['notification_squad']:
             mentions.extend(config['notification_squad'][key])
             del config['notification_squad'][key]
-            asyncio.create_task(config.update())
+            self.bot.loop.create_task(config.update())
         
         return ' '.join(mentions)
 

--- a/core/thread.py
+++ b/core/thread.py
@@ -47,7 +47,7 @@ class Thread:
         '''Close a thread now or after a set time in seconds'''
 
         if after > 0:
-            return await self.bot.loop.call_later(after, silent, delete_channel, message)
+            return self.bot.loop.call_later(after, silent, delete_channel, message)
 
         return await self._close(closer, silent, delete_channel, message)
 

--- a/core/thread.py
+++ b/core/thread.py
@@ -69,7 +69,7 @@ class Thread:
                 'delete_channel': delete_channel,
                 'message': message
             }
-            closures[self.id] = items
+            closures[str(self.id)] = items
             self.bot.config['closures'] = closures
             await self.bot.config.update()
 
@@ -83,6 +83,12 @@ class Thread:
     async def _close(self, closer, silent=False, delete_channel=True,
                      message=None, scheduled=False):
         del self.manager.cache[self.id]
+
+        closures = self.bot.config.get('closures', {})
+        closures.pop(str(self.id))
+        self.bot.config['closures'] = closures
+        await self.bot.config.update()
+
         if str(self.id) in self.bot.config.subscriptions:
             del self.bot.config.subscriptions[str(self.id)]
 

--- a/core/thread.py
+++ b/core/thread.py
@@ -69,7 +69,7 @@ class Thread:
                 'message': message
             }
             closures[self.id] = items
-            self.bot.config['closure'] = closures
+            self.bot.config['closures'] = closures
             await self.bot.config.update()
 
             self.close_task = self.bot.loop.call_later(

--- a/core/thread.py
+++ b/core/thread.py
@@ -40,7 +40,7 @@ class Thread:
         if flag is True:
             self.ready_event.set()
     
-    async def _close_after(self, closer, silent, delete_channel, message):
+    def _close_after(self, closer, silent, delete_channel, message):
         return self.bot.loop.create_task(self._close(closer, silent, delete_channel, message, True))
 
     async def close(self, *, closer, after=0, silent=False, delete_channel=True, message=None):

--- a/core/thread.py
+++ b/core/thread.py
@@ -51,7 +51,7 @@ class Thread:
             self.close_task.cancel()
 
         if after > 0:
-            self.close_task = self.bot.loop.call_later(after, self._close_after, silent, delete_channel, message)
+            self.close_task = self.bot.loop.call_later(after, self._close_after, closer, silent, delete_channel, message)
             return
 
         return await self._close(closer, silent, delete_channel, message)

--- a/core/thread.py
+++ b/core/thread.py
@@ -58,6 +58,7 @@ class Thread:
         if after > 0:
             # TODO: Add somewhere to clean up broken closures
             #  (when channel is already deleted)
+            await self.bot.config.update()
             closures = self.bot.config.get('closures', {})
             now = datetime.datetime.utcnow()
             items = {

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.0
+python-3.7.1


### PR DESCRIPTION
According to [Automatic dyno restarts](https://devcenter.heroku.com/articles/dynos#automatic-dyno-restartsl), all dynos will restart at least once every 27 hours. 

> Dynos are also restarted (cycled) at least once per day to help maintain the health of applications running on Heroku. Any changes to the local filesystem will be deleted. The cycling happens once every 24 hours (plus up to 216 random minutes, to prevent every dyno for an application from restarting at the same time). 

During this period, local caches are deleted, which results in the inability to set the scheduled closure time to longer than 24 hours.
 
---

This PR resolves this issue.
#Fixes #134 

 - Use `call_later()` instead of `sleep()` for schelduling.
 - Created a new internal config var: `closures`.
 - Bot:
    - loads `closures` upon start
    - removes `closures['id']` upon deletion 

Format: 

    'closures': {
        'recipient id': {
            'time': 'ISO 8601 time string',
            'closer_id': int,
            'silent': bool,
            'delete_channel': bool,
            'message': 'message string'
        },
        ...
    }

Unresolved Known Issues
-------------------------
  - During the bot's downtime (when bot restarts), messages during this period are ignored. Therefore the close schedule will not terminate.

---

# Aside

#Addresses #133 

 - Improved formatting in core/config.py

---

**Please carefully review this PR and minor version bump upon approval.**