### PR TITLE
Fix typo in category help doc

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -120,7 +120,7 @@ class Modmail:
     @commands.command()
     @commands.has_permissions(manage_channels=True)
     async def move(self, ctx, *, category: discord.CategoryChannel):
-        """Moves a thread to a specified cateogry."""
+        """Moves a thread to a specified category."""
         thread = await self.bot.threads.find(channel=ctx.channel)
         if not thread:
             return await ctx.send('This is not a modmail thread.')


### PR DESCRIPTION
Typo: """Moves a thread to a specified cateogry."""
Fixed: """Moves a thread to a specified category."""