### PR TITLE
Implement minimum account age requirement and temp blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Introduced a new configuration variable `account_age` for setting a minimum account creation age.
   - Users blocked by this reason will be stored in `blocked` along with other reasons for being blocked.
-  - `account_age` needs to be an ISO8601 Duration Format (examples: `P12DT3H` 12 days and 3 hours, `P3Y5M` 3 years and 5 months `PT4H14M999S` 4 hours 14 minutes and 999 seconds). https://en.wikipedia.org/wiki/ISO_8601#Durations.
+  - `account_age` needs to be an ISO-8601 Duration Format (examples: `P12DT3H` 12 days and 3 hours, `P3Y5M` 3 years and 5 months `PT4H14M999S` 4 hours 14 minutes and 999 seconds). https://en.wikipedia.org/wiki/ISO_8601#Durations.
+  - You can set `account_age` using `config set account_age time` where "time" can be a simple human readable time string or an ISO-8601 Duration Format string.
 
 ### Changed
 - `block` reason cannot start with `System Message: ` as it is now reserved for internal user blocking.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Introduced a new configuration variable `account_age` for setting a minimum account creation age.
-  - This utilizes `blocked` configuration variable to keep track of users under the limit.
+  - Blocked users for this reason will be stored in `blocked` along with other reasons for being blocked.
+  - `account_age` needs to be an ISO8601 Duration Format (examples: `P12DT3H` 12 days and 3 hours, `P3Y5M` 3 years and 5 months `PT4H14M999S` 4 hours 14 minutes and 999 seconds). https://en.wikipedia.org/wiki/ISO_8601#Durations.
 
 ### Changed
 - `block` reason cannot start with `System Message: ` as it is now reserved for internal user blocking.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Unreleased]
+
+### Added
+- Addresses #175.
+- Introduced a new configuration variable `account_age` for setting a minimum account creation age.
+  - This uses `blocked` to keep track of the users under the limit.
+
+### Changed
+- `block` reason cannot start with `System Message: ` as it is now reserved for internal user blocking.
+
 # v2.13.7
 
 ### Added
-
 - The ability to enable typing interactions. 
-
-If you want the bot to type in the thread channel if the user is also typing, add the config variable `user_typing`, the value doesnt matter, just it's presence. use `config del` to disable the functionality. The same thing in reverse is also possible, if you want the user to see the bot type when someone is typing in the thread channel add the `mod_typing` config variable. 
-
+  - If you want the bot to type in the thread channel if the user is also typing, add the config variable `user_typing`, the value doesnt matter, just it's presence. use `config del` to disable the functionality. The same thing in reverse is also possible, if you want the user to see the bot type when someone is typing in the thread channel add the `mod_typing` config variable.
 - New `status` command, change the bot's status to `online`, `idle`, `dnd`, `invisible`, or `offline`.
   - To remove the status (change it back to default), use `status clear`.
   - This also introduces a new internal configuration variable: `status`. Possible values are `online`, `idle`, `dnd`, `invisible`, and `offline`.
@@ -22,8 +29,7 @@ If you want the bot to type in the thread channel if the user is also typing, ad
 # v2.13.6
 
 ### Fixed
-
-Fixed a bug in the contact command where the response message did not send.
+- Fixed a bug in the contact command where the response message did not send.
 
 # v2.13.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - A bug where a thread was blocked from sending messages when multiple images were uploaded, due to a typo.
 
+### changed
+- Uses https://hasteb.in instead of https://hastebin.com for `?debug hastebin`.
+
 # v2.13.7
 
 ### Added
 - The ability to enable typing interactions. 
-  - If you want the bot to type in the thread channel if the user is also typing, add the config variable `user_typing`, the value doesnt matter, just it's presence. use `config del` to disable the functionality. The same thing in reverse is also possible, if you want the user to see the bot type when someone is typing in the thread channel add the `mod_typing` config variable.
+  - If you want the bot to type in the thread channel if the user is also typing, add the config variable `user_typing` and set it to "yes" or "true". use `config del` to disable the functionality. The same thing in reverse is also possible if you want the user to see the bot type when someone is typing in the thread channel add the `mod_typing` config variable.
 - New `status` command, change the bot's status to `online`, `idle`, `dnd`, `invisible`, or `offline`.
   - To remove the status (change it back to default), use `status clear`.
   - This also introduces a new internal configuration variable: `status`. Possible values are `online`, `idle`, `dnd`, `invisible`, and `offline`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Addresses #175.
 - Introduced a new configuration variable `account_age` for setting a minimum account creation age.
-  - This uses `blocked` to keep track of the users under the limit.
+  - This utilizes `blocked` configuration variable to keep track of users under the limit.
 
 ### Changed
 - `block` reason cannot start with `System Message: ` as it is now reserved for internal user blocking.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Introduced a new configuration variable `account_age` for setting a minimum account creation age.
-  - Blocked users for this reason will be stored in `blocked` along with other reasons for being blocked.
+  - Users blocked by this reason will be stored in `blocked` along with other reasons for being blocked.
   - `account_age` needs to be an ISO8601 Duration Format (examples: `P12DT3H` 12 days and 3 hours, `P3Y5M` 3 years and 5 months `PT4H14M999S` 4 hours 14 minutes and 999 seconds). https://en.wikipedia.org/wiki/ISO_8601#Durations.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [Unreleased]
 
 ### Added
-- Addresses #175.
 - Introduced a new configuration variable `account_age` for setting a minimum account creation age.
   - This utilizes `blocked` configuration variable to keep track of users under the limit.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # v2.13.8
 
 ### Fixed
-- A bug where a thread was blocked from sending messsages when multiple images were uploaded. (This was due to a typo)
+- A bug where a thread was blocked from sending messages when multiple images were uploaded, due to a typo.
 
 # v2.13.7
 
@@ -42,9 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - You will no longer need to view your bot debug logs from Heroku. `debug` will show you the you the recent logs within 24h through a series of embeds.
-  - If you don't mind your data (may or may not be limited to: user ID, guild ID, bot name) be on the internet, `debug hastebin` will upload a formatted logs file to https://hastebin.com.
+  - If you don't mind your data (may or may not be limited to: user ID, guild ID, bot name) be on the internet, `debug hastebin` will upload a formatted logs file to https://hasteb.in.
   - `debug clear` will clear the locally cached logs.
-  - Local logs are automatically cleared at least once every 27h.
+  - Local logs are automatically cleared at least once every 27h for bots hosted on Heroku.
 
 ### Fixed
 - Will no longer show  `Unclosed client session` and `Task was destroyed but it is pending!` when the bot terminates.
@@ -75,21 +75,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Installing `requirements.txt` files in plugins.
 
-
 # v2.13.1
 
 ### Fixed
 - Reading `requirements.txt` files in plugins.
 
-
 # v2.13.0
 
 ### Added 
-- Plugins
-    - Think of it like addons! Anyone (with the skills) can create a plugin, make it public and distribute it.    
-    Add a welcome message to Modmail, or moderation commands? It's all up to your imagination!    
-    Have a niche feature request that you think only your server would benefit from? Plugins are your go-to!
-    - [Creating Plugins Documention](https://github.com/kyb3r/modmail/wiki/Plugins).
+- Plugins:
+  - Think of it like addons! Anyone (with the skills) can create a plugin, make it public and distribute it. Add a welcome message to Modmail, or moderation commands? It's all up to your imagination!    Have a niche feature request that you think only your server would benefit from? Plugins are your go-to!
+  - [Creating Plugins Documentation](https://github.com/kyb3r/modmail/wiki/Plugins).
 
 # v2.12.5
 
@@ -127,19 +123,17 @@ Huge thanks to Sasiko for reporting these issues.
 # v2.12.0
 
 ### Important 
-
-In the future, the Modmail API (https://modmail.tk) will be deprecated. This is due to the fact that we are providing a free service without getting anything in return, and thus we do not have the resources to scale to accomodate for more users. We recommend using your own database for logs. In the future you will soon get a `backup` command so you can download all your pre-existing data and migrate to your own database. 
+**In the future, the Modmail API (https://modmail.tk) will be deprecated. This is due to the fact that we are providing a free service without getting anything in return, and thus we do not have the resources to scale to accommodate for more users. 
+We recommend using your own database for logs. In the future you will soon get a `backup` command so you can download all your pre-existing data and migrate to your own database.** 
 
 ### Changed
-- A lot of painful code cleanup, which is good for us (the devs), but shouldn't affect you.
+- A lot of painful code cleanup, which is good for us (the developers), but shouldn't affect you.
 - The appearance of the `logs` command. Should be clearer with better info now.
 - Bot owners get access to all commands regardless of server permissions.
 - Blocked users no longer receive a message, only the blocked emoji will be sent.
 
 ### Added
-
-**Note:** The following commands only work if you are selfhosting your logs. We recommend you to use your own database.
-
+- **Note:** The following commands only work if you are self-hosting your logs. We recommend you to use your own database.
 - Log search queries, in the form of two new commands. 
 - `logs search [query]` - this searches all log messages for a query string.
 - `logs closed-by [user]` this returns all logs closed by a certain user
@@ -168,7 +162,7 @@ In the future, the Modmail API (https://modmail.tk) will be deprecated. This is 
 
 ### Added
 - `anonreply` command to anonymously reply to the recipient. 
-The username of the anonymous user defaults to the `mod_tag` (the footer text of a mod reply). The avatar defaults the guild icon url. However you can change both of these via the `anon_username`, `anon_avatar_url` and `anon_tag` config variables. 
+The username of the anonymous user defaults to the `mod_tag` (the footer text of a mod reply message). The avatar defaults the guild icon URL. However you can change both of these via the `anon_username`, `anon_avatar_url` and `anon_tag` config variables. 
 
 ### Changed
 - Your bot now logs all messages sent in a thread channel, including discussions that take place. You can now toggle to view them in the log viewer app.
@@ -200,13 +194,12 @@ The username of the anonymous user defaults to the `mod_tag` (the footer text of
 
 # v2.9.1
 
-Changed order of arguments for the contact command. This is so that you can use aliases to their full potential. 
-For example: 
-- `contact "Recruitment Category" @somedude` 
-
-You can add an alias by doing: `alias add recruit contact "Recruitment Category"`
-
-Now you can use the alias via: `recruit @somedude`
+### Changed
+- Changed order of arguments for `contact`. This is so that you can use aliases to their full potential. 
+- For example: 
+  - `contact "Recruitment Category" @somedude`
+- You can add an alias by doing: `alias add recruit contact "Recruitment Category"`.
+  - Now you can use the alias via: `recruit @somedude`.
 
 # v2.9.0
 
@@ -244,7 +237,7 @@ Thread channels will now default to being private (`@everyone`'s read message pe
 - `log_channel_id` is now part of the config upon `setup`.
 - Added the ability to set where threads are created using the `main_category_id` configuration option.
 
-### Important Note
+### Note
 
 - If your Modmail bot was set up a long time ago, you may experience an issue where messages were sent outside of the category.
   - To fix this, set `main_category_id` to the ID of the Modmail category.
@@ -258,12 +251,13 @@ Thread channels will now default to being private (`@everyone`'s read message pe
 
 # v2.6.3
 
-Fixed small issue with finding thread.
+### Fixes
+- Fixed small issue with finding thread.
 
 # v2.6.2
 
-Fixed log URLs for self-hosting users.
-(This shouldn't affect anyone.)
+### Fixes
+- Fixed log URLs for self-hosting users.
 
 # v2.6.1
 
@@ -272,8 +266,6 @@ Fixed log URLs for self-hosting users.
 
 # v2.6.0
 
-Mostly internal changes. Some are slightly breaking. Keep a lookout for broken features and report them on our server.
-
 ### Added
 - `threads` is now a default alias to `logs`.
 
@@ -281,30 +273,31 @@ Mostly internal changes. Some are slightly breaking. Keep a lookout for broken f
 - Log URLs are moved to their own collection.
 - Log URLs are now `https://logs.modmail.tk/LOGKEY`, no more numbers before the log key.
 - We still support the numbers so as to not break everyone's URLs so quickly but both work at the moment.
-- This is a huge change to the backend logging and there might be migration errors. If so, please contact us at our [discord server](https://discord.gg/2fMbf2N)
+- This is a huge change to the backend logging and there might be migration errors. If so, please contact us in our [discord server](https://discord.gg/2fMbf2N).
 
 # v2.5.2
 
-Non breaking internal changes.
-(This shouldn't affect anyone.)
+### Fixes
+- Fixed a bug where requests sent when the API was not ready.
+
+# v2.5.1
+
+### Fixes
+- Emergency patch to save config.
 
 # v2.5.0
 
-Non breaking internal changes.
-(This shouldn't affect anyone.)
-
 ### Background
-Bots hosted by Heroku restart at least once every 27 hours.
-During this period, local caches are deleted, which results in the inability to set the scheduled close time to longer than 24 hours. This update resolves this issue. 
- - [PR #135](https://github.com/kyb3r/modmail/pull/135)
-
+- Bots hosted by Heroku restart at least once every 27 hours.
+- During this period, local caches are deleted, which results in the inability to set the scheduled close time to longer than 24 hours. This update resolves this issue. 
+- [PR #135](https://github.com/kyb3r/modmail/pull/135)
 
 ### Changed
- - Created a new internal config var: `closures`.
- - Store closure details into `closures` when the scheduled time isn't "now".
-   - Loaded upon bot restart.
-   - Deleted when a thread is closed.
- - Use `call_later()` instead of `sleep()` for scheduling.
+- Created a new internal config var: `closures`.
+- Store closure details into `closures` when the scheduled time isn't "now".
+  - Loaded upon bot restart.
+  - Deleted when a thread is closed.
+- Use `call_later()` instead of `sleep()` for scheduling.
 
 # v2.4.5
 
@@ -317,8 +310,6 @@ Fixed activity setting due to flawed logic in `config.get()` function.
 Fixed a bug in activity command where it would fail to set the activity on bot restart if the activity type was `playing`.
 
 # v2.4.3
-
-This update shouldn't affect anyone.
 
 ### Changed
  - Moved self-hosted log viewer to a separate repo.
@@ -334,8 +325,6 @@ This update shouldn't affect anyone.
 - Small bug in `activity` command.
 
 # v2.4.0
-
-Breaking changes.
 
 ### Added
 - Added the `activity` command for setting the activity
@@ -356,18 +345,19 @@ Breaking changes.
 - This only applies to separate server setups.
 
 ### Fixed
-- Bug in subscribe command; it will now unsubscribe after a thread is closed.
+- Bug in subscribe command.
+  - It will now unsubscribe after a thread is closed.
 
 # v2.2.0
 
 ### Added
 - Notify command `notify [role]`.
-    - Notify a given role or yourself to the next thread message received.
-    - Once a thread message is received you will be pinged once only.
+  - Notify a given role or yourself to the next thread message received.
+  - Once a thread message is received you will be pinged once only.
 
 - Subscribe command `sub [role]` / `unsub [role]`.
-    - Subscribes yourself or a given role to be notified when thread messages are received.
-    - You will be pinged for every thread message received until you unsubscribe.
+  - Subscribes yourself or a given role to be notified when thread messages are received.
+  - You will be pinged for every thread message received until you unsubscribe.
 
 ### Changed
 - Slightly improved log channel message format.
@@ -381,14 +371,14 @@ Breaking changes.
 
 ### Added
 - Ability to set a custom thread creation response message.
-    - Via `config set thread_creation_response [message]`.
+  - Via `config set thread_creation_response [message]`.
 
 ### Changed
 - Improve logs command format.
 - Improve thread log channel message to have more relevant info.
 - Improve close command.
-    - You now can close the thread after a delay and use a custom thread close message.
-    - You also now have the ability to close a thread silently.
+  - You now can close the thread after a delay and use a custom thread close message.
+  - You also now have the ability to close a thread silently.
 
 # v2.0.10
 
@@ -398,37 +388,33 @@ Breaking changes.
 # v2.0.9
 
 ### Added
-- Support for custom blocked emoji and sent emoji.
-- Use the `config set blocked_emoji` or `sent_emoji` commands.
+- Support for custom blocked and sent emoji.
+- Use the `config set blocked_emoji [emoji]` or `sent_emoji` commands.
 
-### Quick Fix
+### Fixes
 - Support multiple images and file attachments in one message.
 - This is only possible on mobile so its good to handle it in code.
 
 # v2.0.8
 
-Improvements to commands and new config options available.
-
 ### Added
 - Added the ability to use your own log channel.
-    - You can do this via the `config set log_channel_id <id>` command.
+  - You can do this via the `config set log_channel_id <id>` command.
 - Added the ability to use your own main inbox category.
-    - You can do this via the `config set main_category_id <id>` command.
+  - You can do this via the `config set main_category_id <id>` command.
 
 ### Changed
 - You now have the ability to supply a reason when blocking a user.
 - Blocked users are now stored in the database instead of in the channel topic.
-    - This means you can delete the top channel in the Modmail category now. (Migrate first though.)
+  - This means you can delete the top channel in the Modmail category now (after migrating the currently blocked users).
 
 # v2.0.7
-
-New command and improvements in bot update message interfaces.
 
 ### Added
 - Added a `changelog` command to view the bot's changelog within discord.
 
 ### Changed
-- `update` command now shows the latest changes directly from the [CHANGELOG.md](https://modmail.tk/) in the repo.
+- `update` command now shows the latest changes directly from CHANGELOG.md.
 - Auto update messages also show the latest changes from the GitHub repo.
 - Removed "latest changes" section from the `about` command.
 
@@ -437,7 +423,7 @@ New command and improvements in bot update message interfaces.
 ### Fixed
 - Fix logs sending duplicated thread close logs.
 - The bot will now tell you that a user is no longer in the server when you try to reply to a thread.
-    - Before this, it looked like you replied to the thread, but in reality, the message didn't get sent.
+  - Before this, it looked like you replied to the thread, but in reality, the message was not sent.
 
 # v2.0.5
 
@@ -453,26 +439,22 @@ New command and improvements in bot update message interfaces.
 
 # v2.0.3
 
-Fixed some issues with how data is displayed in the info embed.
-
 ### Fixed
 - Thread creation embed now shows the correct number of past logs.
 - If using a separate server setup, roles in the info embed now are shown as names instead of mentions.
-    - This is due to the fact that you can't mention roles across servers.
+  - This is due to the fact that you can't mention roles across servers.
 
 # v2.0.2
 
 ### Security
 - Made the `logs` command require "manage messages" permissions to execute.
-    - Before this patch, anyone could use the `logs` commands.
+  - Before this patch, anyone could use the `logs` commands.
 
 # v2.0.1
 
-Bug fixes and minor improvements.
-
 ### Changed
-- Improved `block`/`unblock` commands.
-    - They now take a wider range of arguments: usernames, nicknames, mentions and user IDs.
+- Improved `block` / `unblock` commands.
+  - They now take a wider range of arguments: usernames, nicknames, mentions and user IDs.
 
 ### Fixed
 - Setup command now configures permissions correctly so that the bot will always be able to see the main operations category.
@@ -496,7 +478,7 @@ Read the updated installation guide [here](https://github.com/kyb3r/modmail/wiki
 - Dynamic `help` command (#84).
 - Dynamic configuration through `api.modmail.tk`.
 - Thread logs via `logs.modmail.tk` (#78).
-    - `log` command added.
+  - `log` command added.
 - Automatic updates (#73).
 - Dynamic command aliases and snippets (#86).
 - Optional support for using a separate guild as the operations center (#81).
@@ -504,4 +486,4 @@ Read the updated installation guide [here](https://github.com/kyb3r/modmail/wiki
 
 ### Removed
 - Removed `archive` command.
-    - Explanation: With thread logs (that lasts forever), there's no point in archiving.
+  - Explanation: With thread logs (that lasts forever), there's no point in archiving.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `block` reason cannot start with `System Message: ` as it is now reserved for internal user blocking.
+- `block`, like `close`, now support a block duration (temp blocking).
 
 # v2.13.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # v2.13.5
 
 ### Added
-- You will no longer need to view your bot debug logs from Heroku. `debug` will show you the you the recent logs within 24h through a series of embeds.
+- You will no longer need to view your bot debug logs from Heroku. `debug` will show you the recent logs within 24h through a series of embeds.
   - If you don't mind your data (may or may not be limited to: user ID, guild ID, bot name) be on the internet, `debug hastebin` will upload a formatted logs file to https://hasteb.in.
   - `debug clear` will clear the locally cached logs.
   - Local logs are automatically cleared at least once every 27h for bots hosted on Heroku.
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `print` is replaced by logging.
   - New environment variable introduced: `LOG_LEVEL`.
-  - This influences the amount of messages received in Heroku logs. 
+  - This influences the number of messages received in Heroku logs. 
   - Possible options, from least to most severe, are: `INFO`, `DEBUG`, `WARNING`, `ERROR`, `CRITICAL`.
   - In most cases, you can ignore this change.
 - `on_error` and `CommandNotFound` are now logged.
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # v2.13.4
 
 ### Changed
-- `?contact` no longer raise a silent error in Heroku logs when the recipient is a bot. Now Modmail respond with an error message.
+- `?contact` no longer raise a silent error in Heroku logs when the recipient is a bot. Now Modmail responds with an error message.
 
 # v2.13.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [Unreleased]
+# v2.13.9
 
 ### Added
 - Introduced a new configuration variable `account_age` for setting a minimum account creation age.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - A bug where a thread was blocked from sending messages when multiple images were uploaded, due to a typo.
 
-### changed
+### Changed
 - Uses https://hasteb.in instead of https://hastebin.com for `?debug hastebin`.
 
 # v2.13.7

--- a/bot.py
+++ b/bot.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-__version__ = '2.13.9'
+__version__ = '2.13.10'
 
 import asyncio
 import logging

--- a/bot.py
+++ b/bot.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-__version__ = '2.13.8'
+__version__ = '2.13.9'
 
 import asyncio
 import logging

--- a/bot.py
+++ b/bot.py
@@ -614,7 +614,7 @@ class ModmailBot(Bot):
             )
             self.dispatch('command_error', ctx, exc)
 
-    async def on_typing(self, channel, user, when):
+    async def on_typing(self, channel, user, _):
         if isinstance(channel, discord.DMChannel):
             if not self.config.get('user_typing'):
                 return

--- a/bot.py
+++ b/bot.py
@@ -468,14 +468,18 @@ class ModmailBot(Bot):
         sent_emoji, blocked_emoji = await self.retrieve_emoji()
 
         account_age = self.config.get('account_age')
-        try:
-            account_age = isodate.parse_duration(account_age)
-        except isodate.ISO8601Error:
-            logger.warning('The account age limit needs to be a ISO8601 duration formatted '
-                           f'duration string greater than 0 days, not "{account_age}".')
-            del self.config.cache['account_age']
-            await self.config.update()
+        if account_age is None:
             account_age = isodate.duration.Duration()
+        else:
+            try:
+                account_age = isodate.parse_duration(account_age)
+            except isodate.ISO8601Error:
+                logger.warning('The account age limit needs to be a '
+                               'ISO-8601 duration formatted duration string '
+                               f'greater than 0 days, not "{account_age}".')
+                del self.config.cache['account_age']
+                await self.config.update()
+                account_age = isodate.duration.Duration()
 
         reason = self.blocked_users.get(str(message.author.id), '')
         accepted_time = message.author.created_at + account_age

--- a/bot.py
+++ b/bot.py
@@ -468,8 +468,8 @@ class ModmailBot(Bot):
             if account_age < 0:
                 raise ValueError
         except ValueError:
-            logger.warning('The age limit needs to be a whole number, '
-                           f'not "{account_age}".')
+            logger.warning('The age limit needs to be a number greater '
+                           f'than 1 in days, not "{account_age}".')
             del self.config.cache['account_age']
             await self.config.update()
 

--- a/bot.py
+++ b/bot.py
@@ -478,7 +478,7 @@ class ModmailBot(Bot):
             # user account under the age limit
             reaction = blocked_emoji
             if str(message.author.id) not in self.blocked_users or \
-               account_age != int(re.search(r'(\d+) day\(s\)', reason).group(1)):
+               account_age != float(re.search(r'(\d+(?:.\d+)?) day\(s\)', reason).group(1)):
                 new_reason = f'System Message: New Account. Account must be ' \
                     f'created before {account_age} day(s).'
                 self.config.blocked[str(message.author.id)] = new_reason

--- a/bot.py
+++ b/bot.py
@@ -496,14 +496,15 @@ class ModmailBot(Bot):
             # user account has not reached the required time
             reaction = blocked_emoji
             changed = False
+            delta = human_timedelta(min_account_age)
 
             if str(message.author.id) not in self.blocked_users:
-                new_reason = 'System Message: New Account.'
+                new_reason = f'System Message: New Account. Required to wait for {delta}.'
                 self.config.blocked[str(message.author.id)] = new_reason
+                await self.config.update()
                 changed = True
 
             if reason.startswith('System Message: New Account.') or changed:
-                delta = human_timedelta(min_account_age)
                 await message.channel.send(embed=discord.Embed(
                     title='Message not sent!',
                     description=f'Your must wait for {delta} '
@@ -528,7 +529,6 @@ class ModmailBot(Bot):
                         reaction = sent_emoji
                         del self.config.blocked[str(message.author.id)]
                         await self.config.update()
-
         else:
             reaction = sent_emoji
 

--- a/bot.py
+++ b/bot.py
@@ -485,7 +485,7 @@ class ModmailBot(Bot):
                 await message.channel.send(embed=discord.Embed(
                     title='Message not sent!',
                     description='Your Discord account must be '
-                                f'created before at least {account_age} day(s) '
+                                f'created for at least {account_age} day(s) '
                                 f'before you can contact {self.user.mention}.',
                     color=discord.Color.red()
                 ))

--- a/bot.py
+++ b/bot.py
@@ -447,7 +447,7 @@ class ModmailBot(Bot):
                 )
             except commands.BadArgument:
                 logger.warning(info(f'Sent Emoji ({sent_emoji}) '
-                                    f'is not a emoji.'))
+                                    f'is not a valid emoji.'))
                 del self.config.cache['sent_emoji']
                 await self.config.update()
 
@@ -458,7 +458,7 @@ class ModmailBot(Bot):
                 )
             except commands.BadArgument:
                 logger.warning(info(f'Blocked emoji ({blocked_emoji}) '
-                                    'is not a emoji.'))
+                                    'is not a valid emoji.'))
                 del self.config.cache['blocked_emoji']
                 await self.config.update()
 

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -712,7 +712,7 @@ class Modmail:
         if str(user.id) not in self.bot.blocked_users or extend or msg.startswith('System Message: '):
             if str(user.id) in self.bot.blocked_users:
 
-                old_reason = msg.strip('. \n\r') or 'no reason'
+                old_reason = msg.strip().rstrip('.') or 'no reason'
                 embed = discord.Embed(
                     title='Success',
                     description=f'{mention} was previously blocked for '
@@ -764,7 +764,9 @@ class Modmail:
             await self.bot.config.update()
 
             if msg.startswith('System Message: '):
-                reason = msg[16:].strip('. \n\r')
+                # If the user is blocked internally (for example: below minimum account age)
+                # Show an extended message stating the original internal message
+                reason = msg[16:].strip().rstrip('.') or 'no reason'
                 embed = discord.Embed(
                     title='Success',
                     description=f'{mention} was previously blocked internally due to '

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -731,10 +731,10 @@ class Modmail:
 
         mention = user.mention if hasattr(user, 'mention') else f'`{user.id}`'
 
-        system = self.bot.blocked_users.get(str(user.id),
-                                            '').startswith('System Message: ')
-
         if str(user.id) in self.bot.blocked_users:
+            system = self.bot.blocked_users.get(str(user.id), '').startswith(
+                'System Message: '
+            )
             if system:
                 reason = self.bot.blocked_users.get(str(user.id))[16:]
                 embed = discord.Embed(

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -739,18 +739,17 @@ class Modmail:
                 reason = self.bot.blocked_users.get(str(user.id))[16:]
                 embed = discord.Embed(
                     title='Error',
-                    description=f'{mention} is blocked internally due to '
-                                f'{reason}, unable to unblock.',
-                    color=discord.Color.red()
+                    description=f'{mention} is blocked internally due to {reason}.',
+                    color=self.bot.main_color
                 )
-            else:
-                del self.bot.config.blocked[str(user.id)]
-                await self.bot.config.update()
-                embed = discord.Embed(
-                    title='Success',
-                    color=self.bot.main_color,
-                    description=f'{mention} is no longer blocked.'
-                )
+                await ctx.send(embed=embed)
+            del self.bot.config.blocked[str(user.id)]
+            await self.bot.config.update()
+            embed = discord.Embed(
+                title='Success',
+                color=self.bot.main_color,
+                description=f'{mention} is no longer blocked.'
+            )
         else:
             embed = discord.Embed(
                 title='Error',

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -694,7 +694,7 @@ class Modmail:
         system = self.bot.blocked_users.get(str(user.id),
                                             '').startswith('System Message: ')
         if str(user.id) not in self.bot.blocked_users or system:
-            self.bot.config.blocked[str(user.id)] = reason
+            self.bot.config.blocked[str(user.id)] = reason if reason else None
             await self.bot.config.update()
             extend = f'for `{reason}`' if reason else ''
             embed = discord.Embed(

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -674,7 +674,8 @@ class Modmail:
     @commands.command()
     @trigger_typing
     @checks.has_permissions(manage_channels=True)
-    async def block(self, ctx, user: User = None, *, after: UserFriendlyTime = None):
+    async def block(self, ctx, user: Optional[User] = None, *,
+                    after: UserFriendlyTime = None):
         """
         Block a user from using Modmail.
 

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -5,6 +5,8 @@ from typing import Optional, Union
 import discord
 from discord.ext import commands
 
+import re
+
 from dateutil import parser
 from natural.date import duration
 
@@ -672,16 +674,14 @@ class Modmail:
     @commands.command()
     @trigger_typing
     @checks.has_permissions(manage_channels=True)
-    async def block(self, ctx, user: User = None, *, reason: str = ''):
+    async def block(self, ctx, user: User = None, *, after: UserFriendlyTime = None):
         """
         Block a user from using Modmail.
 
         Note: reasons start with "System Message: " are reserved for internal
         use only.
         """
-
-        if reason.startswith('System Message: '):
-            raise commands.UserInputError
+        reason = ''
 
         if user is None:
             thread = ctx.thread
@@ -690,23 +690,48 @@ class Modmail:
             else:
                 raise commands.UserInputError
 
+        if after is not None:
+            reason = after.arg
+            if reason.startswith('System Message: '):
+                raise commands.UserInputError
+            elif re.search(r'%(.+?)%$', reason) is not None:
+                raise commands.UserInputError
+            elif after.dt > after.now:
+                reason = f'{reason} %{after.dt.isoformat()}%'
+
+        if not reason:
+            reason = None
+
         mention = user.mention if hasattr(user, 'mention') else f'`{user.id}`'
-        system = self.bot.blocked_users.get(str(user.id),
-                                            '').startswith('System Message: ')
-        if str(user.id) not in self.bot.blocked_users or system:
-            self.bot.config.blocked[str(user.id)] = reason if reason else None
+
+        extend = f' for `{reason}`' if reason is not None else ''
+        msg = self.bot.blocked_users.get(str(user.id))
+        if msg is None:
+            msg = ''
+
+        if str(user.id) not in self.bot.blocked_users or extend or msg.startswith('System Message: '):
+            if str(user.id) in self.bot.blocked_users:
+
+                old_reason = msg.strip('. \n\r') or 'no reason'
+                embed = discord.Embed(
+                    title='Success',
+                    description=f'{mention} was previously blocked for '
+                    f'"{old_reason}". {mention} is now blocked{extend}.',
+                    color=self.bot.main_color
+                )
+            else:
+                embed = discord.Embed(
+                    title='Success',
+                    color=self.bot.main_color,
+                    description=f'{mention} is now blocked{extend}.'
+                )
+            self.bot.config.blocked[str(user.id)] = reason
             await self.bot.config.update()
-            extend = f'for `{reason}`' if reason else ''
-            embed = discord.Embed(
-                title='Success',
-                color=self.bot.main_color,
-                description=f'{mention} is now blocked {extend}.'
-            )
         else:
             embed = discord.Embed(
                 title='Error',
                 color=discord.Color.red(),
-                description=f'{mention} is already blocked,'
+                description=f'{mention} is already blocked.'
             )
 
         return await ctx.send(embed=embed)
@@ -732,7 +757,9 @@ class Modmail:
         mention = user.mention if hasattr(user, 'mention') else f'`{user.id}`'
 
         if str(user.id) in self.bot.blocked_users:
-            msg = self.bot.blocked_users.get(str(user.id), '')
+            msg = self.bot.blocked_users.get(str(user.id))
+            if msg is None:
+                msg = ''
             del self.bot.config.blocked[str(user.id)]
             await self.bot.config.update()
 

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -672,7 +672,7 @@ class Modmail:
     @commands.command()
     @trigger_typing
     @checks.has_permissions(manage_channels=True)
-    async def block(self, ctx, user: User = None, *, reason: str = None):
+    async def block(self, ctx, user: User = None, *, reason: str = ''):
         """
         Block a user from using Modmail.
 

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -732,24 +732,24 @@ class Modmail:
         mention = user.mention if hasattr(user, 'mention') else f'`{user.id}`'
 
         if str(user.id) in self.bot.blocked_users:
-            system = self.bot.blocked_users.get(str(user.id), '').startswith(
-                'System Message: '
-            )
-            if system:
-                reason = self.bot.blocked_users.get(str(user.id))[16:]
-                embed = discord.Embed(
-                    title='Error',
-                    description=f'{mention} is blocked internally due to {reason}.',
-                    color=self.bot.main_color
-                )
-                await ctx.send(embed=embed)
+            msg = self.bot.blocked_users.get(str(user.id), '')
             del self.bot.config.blocked[str(user.id)]
             await self.bot.config.update()
-            embed = discord.Embed(
-                title='Success',
-                color=self.bot.main_color,
-                description=f'{mention} is no longer blocked.'
-            )
+
+            if msg.startswith('System Message: '):
+                reason = msg[16:].strip('. \n\r')
+                embed = discord.Embed(
+                    title='Success',
+                    description=f'{mention} was previously blocked internally due to '
+                    f'"{reason}". {mention} is no longer blocked.',
+                    color=self.bot.main_color
+                )
+            else:
+                embed = discord.Embed(
+                    title='Success',
+                    color=self.bot.main_color,
+                    description=f'{mention} is no longer blocked.'
+                )
         else:
             embed = discord.Embed(
                 title='Error',

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -603,7 +603,7 @@ class Modmail:
                       category: Optional[discord.CategoryChannel] = None, *,
                       user: Union[discord.Member, discord.User]):
         """Create a thread with a specified member.
-        
+
         If the optional category argument is passed, the thread
         will be created in the specified category.
         """

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -678,7 +678,7 @@ class Modmail:
         """
         Block a user from using Modmail.
 
-        Note: reasons start with "System Message: " are reserved for internal
+        Note: reasons that start with "System Message: " are reserved for internal
         use only.
         """
         reason = ''

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -555,8 +555,8 @@ class Utility:
         else:
             url = None
             activity_message = (
-                    activity_message or
-                    self.bot.config.get('activity_message', '')
+                activity_message or
+                self.bot.config.get('activity_message', '')
             ).strip()
 
             if activity_type == ActivityType.listening:

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -585,7 +585,6 @@ class Utility:
         presence = {'activity': (None, 'No activity has been set.'),
                     'status': (None, 'No status has been set.')}
         if activity is not None:
-            # TODO: Trim message
             to = 'to ' if activity.type == ActivityType.listening else ''
             msg = f'Activity set to: {activity.type.name.capitalize()} '
             msg += f'{to}{activity.name}.'

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -690,7 +690,7 @@ class Utility:
 
         if key in keys:
             try:
-                value, value_text = self.bot.config.clean_data(key, value)
+                value, value_text = await self.bot.config.clean_data(key, value)
             except InvalidConfigError as exc:
                 embed = exc.embed
             else:

--- a/core/config.py
+++ b/core/config.py
@@ -2,8 +2,11 @@ import asyncio
 import json
 import os
 
+import isodate
+
 from core._color_data import ALL_COLORS
 from core.models import Bot, ConfigManagerABC, InvalidConfigError
+from core.time import UserFriendlyTime
 
 
 class ConfigManager(ConfigManagerABC):
@@ -49,6 +52,10 @@ class ConfigManager(ConfigManagerABC):
 
     colors = {
         'mod_color', 'recipient_color', 'main_color'
+    }
+
+    time_deltas = {
+        'account_age'
     }
 
     valid_keys = allowed_to_change_in_command | internal_keys | protected_keys
@@ -103,7 +110,7 @@ class ConfigManager(ConfigManagerABC):
         }
         return self.cache
 
-    def clean_data(self, key, val):
+    async def clean_data(self, key, val):
         value_text = val
         clean_value = val
 
@@ -126,6 +133,21 @@ class ConfigManager(ConfigManagerABC):
                 value_text = clean_value
             else:
                 clean_value = hex_
+                value_text = f'{val} ({clean_value})'
+
+        elif key in self.time_deltas:
+            try:
+                isodate.parse_duration(val)
+            except isodate.ISO8601Error:
+                try:
+                    converter = UserFriendlyTime()
+                    time = await converter.convert(None, val)
+                except Exception:
+                    raise InvalidConfigError(
+                        'Unrecognized time, please use ISO-8601 duration format '
+                        'string or a simpler "human readable" time.'
+                    )
+                clean_value = isodate.duration_isoformat(time.dt - converter.now)
                 value_text = f'{val} ({clean_value})'
 
         return clean_value, value_text

--- a/core/config.py
+++ b/core/config.py
@@ -13,7 +13,7 @@ class ConfigManager(ConfigManagerABC):
         'twitch_url',
         # bot settings
         'main_category_id', 'disable_autoupdates', 'prefix', 'mention',
-        'main_color', 'user_typing', 'mod_typing',
+        'main_color', 'user_typing', 'mod_typing', 'account_age',
         # logging
         'log_channel_id',
         # threads

--- a/core/config.py
+++ b/core/config.py
@@ -4,6 +4,8 @@ import os
 
 import isodate
 
+from discord.ext.commands import BadArgument
+
 from core._color_data import ALL_COLORS
 from core.models import Bot, ConfigManagerABC, InvalidConfigError
 from core.time import UserFriendlyTime
@@ -142,6 +144,10 @@ class ConfigManager(ConfigManagerABC):
                 try:
                     converter = UserFriendlyTime()
                     time = await converter.convert(None, val)
+                    if time.arg:
+                        raise ValueError
+                except BadArgument as e:
+                    raise InvalidConfigError(*e.args)
                 except Exception:
                     raise InvalidConfigError(
                         'Unrecognized time, please use ISO-8601 duration format '

--- a/core/models.py
+++ b/core/models.py
@@ -244,8 +244,8 @@ class ConfigManagerABC(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def clean_data(self, key: str,
-                   val: typing.Any) -> typing.Tuple[str, str]:
+    async def clean_data(self, key: str,
+                         val: typing.Any) -> typing.Tuple[str, str]:
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/core/models.py
+++ b/core/models.py
@@ -394,8 +394,8 @@ class ThreadManagerABC(abc.ABC):
 
 
 class InvalidConfigError(commands.BadArgument):
-    def __init__(self, msg):
-        super().__init__(msg)
+    def __init__(self, msg, *args):
+        super().__init__(msg, *args)
         self.msg = msg
 
     @property

--- a/core/thread.py
+++ b/core/thread.py
@@ -345,7 +345,7 @@ class Thread(ThreadABC):
                                         ))
 
         if self.close_task is not None:
-            # cancel closing if a thread message is sent.
+            # Cancel closing if a thread message is sent.
             await self.cancel_closure()
             tasks.append(
                 self.channel.send(
@@ -361,7 +361,7 @@ class Thread(ThreadABC):
     async def send(self, message, destination=None,
                    from_mod=False, note=False, anonymous=False):
         if self.close_task is not None:
-            # cancel closing if a thread message is sent.
+            # Cancel closing if a thread message is sent.
             tasks = asyncio.gather(
                 self.cancel_closure(),
                 self.channel.send(embed=discord.Embed(
@@ -434,7 +434,7 @@ class Thread(ThreadABC):
         additional_images = []
         additional_count = 1
 
-        for att in images:  # TODO: Logic needs review
+        for att in images:
             if not prioritize_uploads or (
                     is_image_url(*att) and not
                     embedded_image and

--- a/core/time.py
+++ b/core/time.py
@@ -37,10 +37,12 @@ class ShortTime:
         now = datetime.utcnow()
         self.dt = now + relativedelta(**data)
 
+
 # Monkey patch mins and secs into the units
 units = pdt.pdtLocales['en_US'].units
 units['minutes'].append('mins')
 units['seconds'].append('secs')
+
 
 class HumanTime:
     calendar = pdt.Calendar(version=pdt.VERSION_CONTEXT_STYLE)

--- a/core/time.py
+++ b/core/time.py
@@ -95,6 +95,7 @@ class UserFriendlyTime(Converter):
         if converter is not None and not isinstance(converter, Converter):
             raise TypeError('commands.Converter subclass necessary.')
         self.dt = self.arg = None
+        self.now = None
         self.converter = converter
 
     async def check_constraints(self, ctx, now, remaining):
@@ -112,15 +113,15 @@ class UserFriendlyTime(Converter):
         try:
             calendar = HumanTime.calendar
             regex = ShortTime.compiled
-            self.dt = now = datetime.utcnow()
+            self.dt = self.now = datetime.utcnow()
 
             match = regex.match(argument)
             if match is not None and match.group(0):
                 data = {k: int(v) for k, v in
                         match.groupdict(default='0').items()}
                 remaining = argument[match.end():].strip()
-                self.dt = now + relativedelta(**data)
-                return await self.check_constraints(ctx, now, remaining)
+                self.dt = self.now + relativedelta(**data)
+                return await self.check_constraints(ctx, self.now, remaining)
 
             # apparently nlp does not like "from now"
             # it likes "from x" in other cases though
@@ -133,9 +134,9 @@ class UserFriendlyTime(Converter):
                 if argument[0:6] in ('me to ', 'me in ', 'me at '):
                     argument = argument[6:]
 
-            elements = calendar.nlp(argument, sourceTime=now)
+            elements = calendar.nlp(argument, sourceTime=self.now)
             if elements is None or not elements:
-                return await self.check_constraints(ctx, now, argument)
+                return await self.check_constraints(ctx, self.now, argument)
 
             # handle the following cases:
             # "date time" foo
@@ -146,7 +147,7 @@ class UserFriendlyTime(Converter):
             dt, status, begin, end, _ = elements[0]
 
             if not status.hasDateOrTime:
-                return await self.check_constraints(ctx, now, argument)
+                return await self.check_constraints(ctx, self.now, argument)
 
             if begin not in (0, 1) and end != len(argument):
                 raise BadArgument(
@@ -156,14 +157,14 @@ class UserFriendlyTime(Converter):
 
             if not status.hasTime:
                 # replace it with the current time
-                dt = dt.replace(hour=now.hour,
-                                minute=now.minute,
-                                second=now.second,
-                                microsecond=now.microsecond)
+                dt = dt.replace(hour=self.now.hour,
+                                minute=self.now.minute,
+                                second=self.now.second,
+                                microsecond=self.now.microsecond)
 
             # if midnight is provided, just default to next day
             if status.accuracy == pdt.pdtContext.ACU_HALFDAY:
-                dt = dt.replace(day=now.day + 1)
+                dt = dt.replace(day=self.now.day + 1)
 
             self.dt = dt
 
@@ -186,7 +187,7 @@ class UserFriendlyTime(Converter):
             elif len(argument) == end:
                 remaining = argument[:begin].strip()
 
-            return await self.check_constraints(ctx, now, remaining)
+            return await self.check_constraints(ctx, self.now, remaining)
         except Exception:
             logger.exception(
                 error('Something went wrong while parsing the time')

--- a/core/time.py
+++ b/core/time.py
@@ -88,14 +88,16 @@ class FutureTime(Time):
 class UserFriendlyTime(Converter):
     """That way quotes aren't absolutely necessary."""
 
-    def __init__(self, converter=None):
+    def __init__(self, converter: Converter = None):
         if isinstance(converter, type) and issubclass(converter, Converter):
             converter = converter()
 
         if converter is not None and not isinstance(converter, Converter):
             raise TypeError('commands.Converter subclass necessary.')
-        self.dt = self.arg = None
-        self.now = None
+        self.raw: str = None
+        self.dt: datetime = None
+        self.arg = None
+        self.now: datetime = None
         self.converter = converter
 
     async def check_constraints(self, ctx, now, remaining):
@@ -109,6 +111,7 @@ class UserFriendlyTime(Converter):
         return self
 
     async def convert(self, ctx, argument):
+        self.raw = argument
         remaining = ''
         try:
             calendar = HumanTime.calendar
@@ -126,8 +129,11 @@ class UserFriendlyTime(Converter):
             # apparently nlp does not like "from now"
             # it likes "from x" in other cases though
             # so let me handle the 'now' case
-            if argument.endswith('from now'):
-                argument = argument[:-8].strip()
+            if argument.endswith(' from now'):
+                argument = argument[:-9].strip()
+            # handles "for xxx hours"
+            if argument.startswith('for '):
+                argument = argument[4:].strip()
 
             if argument[0:2] == 'me':
                 # starts with "me to", "me in", or "me at "

--- a/core/utils.py
+++ b/core/utils.py
@@ -8,16 +8,6 @@ from discord.ext import commands
 from colorama import Fore, Style
 
 
-class SafeDict(dict):
-    def __missing__(self, key):
-        return '{' + key + '}'
-
-
-def safeformat(s, **kwargs):
-    replacements = SafeDict(**kwargs)
-    return s.format_map(replacements)
-
-
 def info(*msgs):
     return f'{Fore.CYAN}{" ".join(msgs)}{Style.RESET_ALL}'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ emoji>=0.2
 uvloop>=0.12.0
 motor>=2.0.0
 natural==0.2.0
+isodate>=0.6.0
 dnspython~=1.16.0   # required by motor
 parsedatetime==2.4  # to be replaced by dateparser
 aiohttp<3.5         # to comply with discord.py


### PR DESCRIPTION
Addresses #175 #120

# Added
- Introduced a new configuration variable `account_age` for setting a minimum account creation age.
  - Users blocked by this reason will be stored in `blocked` along with other reasons for being blocked.
  - `account_age` needs to be an ISO8601 Duration Format (examples: `P12DT3H` 12 days and 3 hours, `P3Y5M` 3 years and 5 months `PT4H14M999S` 4 hours 14 minutes and 999 seconds). https://en.wikipedia.org/wiki/ISO_8601#Durations.

# Changed
- `block` reason cannot start with `System Message: ` as it is now reserved for internal user blocking.
- `block`, like `close`, now support a block duration (temp blocking).