### PR TITLE
v2.18.0 - new permission system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+# v2.17.1
+
+### Changed
+
+- Stricter fallback genesis embed search. This update shouldn't affect anyone.
+
+### Info
+How modmail checks if a channel is a thread: 
+
+1. First the bot checks if the channel topic is in the format `User ID: xxxx`, this means it is a thread.
+2. If a channel topic is not found, the bot searches through message history of a channel to find the thread creation embed. This step should never yield a thread for a normal user, but in the case of a another bot messing up the channel topic (happened to a user before) this extra step was added. 
+
+
 # v2.17.0
 
 ### What's new?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# v2.16.1
+
+### Fixed
+
+An issue where a scheduled close would not execute over a long period of time if the recipient no shares any servers with the bot.
+
 # v2.16.0
 
 ### What's new?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### What's new?
 
-- A brand new permission system! Replacing the old guild-based permissions (ie. manage channels, manage messages), the new system enables you to customize your desire permission level specific to a command or a group of commands for a role or user.
+- A brand new permission system! Replacing the old guild-based permissions (ie. manage channels, manage messages), the new system enables you to customize your desired permission level specific to a command or a group of commands for a role or user.
 - There are five permission groups/levels:
   - Owner [5]
   - Administrator [4]
@@ -24,11 +24,11 @@ You may add a role or user to a permission group through any of the following me
 - `?permissions add level moderator @member#1234`
 - `?permissions add level administrator 78912384930291853`
 
-The same applies for individual commands permissions:
+The same applies to individual commands permissions:
 - `?permissions add command-name @member#1234`
 - ... and the other methods listed above.
 
-To revoke a permission, use `remove` instead of `add`.
+To revoke permission, use `remove` instead of `add`.
 
 To view all roles and users with permission for a permission group or command do:
 -  `?permissions get command command-name`
@@ -37,6 +37,8 @@ To view all roles and users with permission for a permission group or command do
 By default, all newly set up Modmail will have `OWNER` set to the owner of the bot, and `EGULAR` set to @everyone.
 
 The help message no longer conceal inaccessible commands due to check failures.
+
+A `?delete` command, which is an alternative to manually deleting a message. This command is created to no longer require manage messages permission to recall thread messages.
 
 ### Note
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,12 @@ To view all roles and users with permission for a permission group or command do
 -  `?permissions get command command-name`
 -  `?permissions get level owner`
 
+By default, all newly set up Modmail will have `OWNER` set to the owner of the bot, and `EGULAR` set to @everyone.
+
 ### Note
 
 When updating to this version, all prior permission settings with guild-based permissions will be invalidated. You will need to convert to the above system.
+`OWNERS` will also get removed, you will need to set owners through `?permissions add level owner 212931293123129` or any way listed above.
 
 # v2.17.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A brand new permission system! Replacing the old guild-based permissions (ie. manage channels, manage messages), the new system enables you to customize your desire permission level specific to a command or a group of commands for a role or user.
 - There are five permission groups/levels:
-  - Owner
-  - Administrator
-  - Moderator
-  - Supporter
-  - Regular
+  - Owner [5]
+  - Administrator [4]
+  - Moderator [3]
+  - Supporter [2]
+  - Regular [1]
 
 You may add a role or user to a permission group through any of the following methods:
 - `?permissions add level owner @role`
@@ -35,6 +35,8 @@ To view all roles and users with permission for a permission group or command do
 -  `?permissions get level owner`
 
 By default, all newly set up Modmail will have `OWNER` set to the owner of the bot, and `EGULAR` set to @everyone.
+
+The help message no longer conceal inaccessible commands due to check failures.
 
 ### Note
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+# v2.17.0
+
+### What's new?
+
+Added a config option `reply_without_command` that when present, enables the bot to forward any message sent in a thread channel to the recipient. (Replying without using a command)
+
+To enable this functionality, do `?config set reply_without_command true` and to disable it, use `?config del reply_without_command`.
+
+
+### Changed
+
+The `move` command now only requires `manage_messages` perms instead of `manage_channels`
+
 # v2.16.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+# v2.18.0
+
+### What's new?
+
+- A brand new permission system! Replacing the old guild-based permissions (ie. manage channels, manage messages), the new system enables you to customize your desire permission level specific to a command or a group of commands for a role or user.
+- There are five permission groups/levels:
+  - Owner
+  - Administrator
+  - Moderator
+  - Supporter
+  - Regular
+
+You may add a role or user to a permission group through any of the following methods:
+- `?permissions add level owner @role`
+- `?permissions add level supporter member-name`
+- `?permissions add level moderator everyone`
+- `?permissions add level moderator @member#1234`
+- `?permissions add level administrator 78912384930291853`
+
+The same applies for individual commands permissions:
+- `?permissions add command-name @member#1234`
+- ... and the other methods listed above.
+
+To revoke a permission, use `remove` instead of `add`.
+
+To view all roles and users with permission for a permission group or command do:
+-  `?permissions get command command-name`
+-  `?permissions get level owner`
+
+### Note
+
+When updating to this version, all prior permission settings with guild-based permissions will be invalidated. You will need to convert to the above system.
+
 # v2.17.1
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # v2.18.0
 
-### What's new?
+### New Permissions System
 
 - A brand new permission system! Replacing the old guild-based permissions (ie. manage channels, manage messages), the new system enables you to customize your desired permission level specific to a command or a group of commands for a role or user.
 - There are five permission groups/levels:
@@ -36,14 +36,18 @@ To view all roles and users with permission for a permission group or command do
 
 By default, all newly set up Modmail will have `OWNER` set to the owner of the bot, and `EGULAR` set to @everyone.
 
-The help message no longer conceal inaccessible commands due to check failures.
-
-A `?delete` command, which is an alternative to manually deleting a message. This command is created to no longer require manage messages permission to recall thread messages.
-
 ### Breaking
 
 When updating to this version, all prior permission settings with guild-based permissions will be invalidated. You will need to convert to the above system.
 `OWNERS` will also get removed, you will need to set owners through `?permissions add level owner 212931293123129` or any way listed above.
+
+### New Command
+
+- A `?delete` command, which is an alternative to manually deleting a message. This command is created to no longer require manage messages permission to recall thread messages.
+
+### Changed
+
+- The help message no longer conceals inaccessible commands due to check failures.
 
 
 # v2.17.2

--- a/bot.py
+++ b/bot.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-__version__ = '2.17.0'
+__version__ = '2.17.1'
 
 import asyncio
 import logging

--- a/bot.py
+++ b/bot.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-__version__ = '2.16.0'
+__version__ = '2.16.1'
 
 import asyncio
 import logging
@@ -412,18 +412,15 @@ class ModmailBot(Bot):
                      datetime.utcnow()).total_seconds()
             if after < 0:
                 after = 0
-            recipient = self.get_user(int(recipient_id))
 
-            thread = await self.threads.find(recipient=recipient)
+            thread = await self.threads.find(recipient_id=int(recipient_id))
 
             if not thread:
-                # If the recipient is gone or channel is deleted
+                # If the channel is deleted
                 self.config.closures.pop(str(recipient_id))
                 await self.config.update()
                 continue
 
-            # TODO: Low priority,
-            #  Retrieve messages/replies when bot is down, from history?
             await thread.close(
                 closer=self.get_user(items['closer_id']),
                 after=after,
@@ -431,6 +428,7 @@ class ModmailBot(Bot):
                 delete_channel=items['delete_channel'],
                 message=items['message']
             )
+
         logger.info(LINE)
 
     async def convert_emoji(self, name):

--- a/bot.py
+++ b/bot.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-__version__ = '2.16.1'
+__version__ = '2.17.0'
 
 import asyncio
 import logging
@@ -623,7 +623,10 @@ class ModmailBot(Bot):
 
         thread = await self.threads.find(channel=ctx.channel)
         if thread is not None:
-            await self.api.append_log(message, type_='internal')
+            if self.config.get('reply_without_command'):
+                await thread.reply(message)
+            else:
+                await self.api.append_log(message, type_='internal')
         elif ctx.invoked_with:
             exc = commands.CommandNotFound(
                 'Command "{}" is not found'.format(ctx.invoked_with)

--- a/bot.py
+++ b/bot.py
@@ -781,6 +781,8 @@ class ModmailBot(Bot):
                                  command=str(context.command))
         elif isinstance(exception, commands.CommandNotFound):
             logger.warning(error('CommandNotFound: ' + str(exception)))
+        elif isinstance(exception, commands.CheckFailure):
+            logger.warning(error('CheckFailure: ' + str(exception)))
         else:
             logger.error(error('Unexpected exception:'), exc_info=exception)
 
@@ -914,6 +916,7 @@ class ModmailBot(Bot):
                     await channel.send(embed=embed)
 
             await asyncio.sleep(3600)
+
 
 if __name__ == '__main__':
     if os.name != 'nt':

--- a/bot.py
+++ b/bot.py
@@ -52,7 +52,6 @@ from core.models import Bot, PermissionLevel
 from core.thread import ThreadManager
 from core.time import human_timedelta
 
-
 init()
 
 logger = logging.getLogger('Modmail')
@@ -486,7 +485,8 @@ class ModmailBot(Bot):
             except isodate.ISO8601Error:
                 logger.warning('The account age limit needs to be a '
                                'ISO-8601 duration formatted duration string '
-                               f'greater than 0 days, not "%s".', str(account_age))
+                               f'greater than 0 days, not "%s".',
+                               str(account_age))
                 del self.config.cache['account_age']
                 await self.config.update()
                 account_age = isodate.duration.Duration()
@@ -541,7 +541,7 @@ class ModmailBot(Bot):
                         await self.config.update()
         else:
             reaction = sent_emoji
-        
+
         if reaction != 'disable':
             try:
                 await message.add_reaction(reaction)
@@ -610,7 +610,9 @@ class ModmailBot(Bot):
             else:
                 if value in permissions[name]:
                     permissions[name].remove(value)
-        logger.info(info(f'Updating permissions for {name}, {value} (add={add}).'))
+        logger.info(
+            info(f'Updating permissions for {name}, {value} (add={add}).')
+        )
         await self.config.update()
 
     async def on_message(self, message):
@@ -649,7 +651,7 @@ class ModmailBot(Bot):
 
     async def on_typing(self, channel, user, _):
         if user.bot:
-            return 
+            return
         if isinstance(channel, discord.DMChannel):
             if not self.config.get('user_typing'):
                 return
@@ -662,7 +664,7 @@ class ModmailBot(Bot):
             thread = await self.threads.find(channel=channel)
             if thread and thread.recipient:
                 await thread.recipient.trigger_typing()
-    
+
     async def on_raw_reaction_add(self, payload):
 
         user = self.get_user(payload.user_id)
@@ -682,12 +684,14 @@ class ModmailBot(Bot):
         message = await channel.get_message(payload.message_id)
         reaction = payload.emoji
 
-        close_emoji = await self.convert_emoji(self.config.get('close_emoji', '🔒'))
+        close_emoji = await self.convert_emoji(
+            self.config.get('close_emoji', '🔒')
+        )
 
         if isinstance(channel, discord.DMChannel) and str(reaction) == str(close_emoji):  # closing thread
             thread = await self.threads.find(recipient=user)
             ts = message.embeds[0].timestamp if message.embeds else None
-            if thread and ts == thread.channel.created_at: 
+            if thread and ts == thread.channel.created_at:
                 # the reacted message is the corresponding thread creation embed
                 if not self.config.get('disable_recipient_thread_close'):
                     await thread.close(closer=user)
@@ -733,23 +737,23 @@ class ModmailBot(Bot):
             return
 
         await thread.close(closer=mod, silent=True, delete_channel=False)
-    
+
     async def on_member_remove(self, member):
         thread = await self.threads.find(recipient=member)
         if thread:
             em = discord.Embed(
                 description='The recipient has left the server.',
                 color=discord.Color.red()
-                )
+            )
             await thread.channel.send(embed=em)
-    
+
     async def on_member_join(self, member):
         thread = await self.threads.find(recipient=member)
         if thread:
             em = discord.Embed(
                 description='The recipient has joined the server.',
                 color=self.mod_color
-                )
+            )
             await thread.channel.send(embed=em)
 
     async def on_message_delete(self, message):
@@ -909,7 +913,7 @@ class ModmailBot(Bot):
                 embed.set_author(name=user['username'] + ' - Updating Bot',
                                  icon_url=user['avatar_url'],
                                  url=user['url'])
-                embed.set_footer(text=f"Updating Modmail v{self.version} "
+                embed.set_footer(text=f'Updating Modmail v{self.version} '
                                       f"-> v{metadata['latest_version']}")
 
                 changelog = await Changelog.from_url(self)
@@ -935,6 +939,7 @@ class ModmailBot(Bot):
 if __name__ == '__main__':
     if os.name != 'nt':
         import uvloop
+
         uvloop.install()
     bot = ModmailBot()
     bot.run()

--- a/bot.py
+++ b/bot.py
@@ -741,20 +741,20 @@ class ModmailBot(Bot):
     async def on_member_remove(self, member):
         thread = await self.threads.find(recipient=member)
         if thread:
-            em = discord.Embed(
+            embed = discord.Embed(
                 description='The recipient has left the server.',
                 color=discord.Color.red()
             )
-            await thread.channel.send(embed=em)
+            await thread.channel.send(embed=embed)
 
     async def on_member_join(self, member):
         thread = await self.threads.find(recipient=member)
         if thread:
-            em = discord.Embed(
+            embed = discord.Embed(
                 description='The recipient has joined the server.',
                 color=self.mod_color
             )
-            await thread.channel.send(embed=em)
+            await thread.channel.send(embed=embed)
 
     async def on_message_delete(self, message):
         """Support for deleting linked messages"""

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -142,7 +142,7 @@ class Modmail:
         await ctx.send(embed=embed)
 
     @commands.command()
-    @checks.has_permissions(manage_channels=True)
+    @checks.has_permissions(manage_messages=True)
     async def move(self, ctx, *, category: discord.CategoryChannel):
         """Moves a thread to a specified category."""
         thread = ctx.thread

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -793,9 +793,10 @@ class Modmail:
     @commands.command()
     @checks.has_permissions(PermissionLevel.SUPPORTER)
     async def delete(self, ctx, message_id: int = None):
-        """
+        """Delete a message that was sent using the reply command.
+
         Deletes the previous message, unless a message ID is provided, which in that case,
-        delete the message with that message ID.
+        deletes the message with that message ID.
         """
         thread = ctx.thread
 

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1,11 +1,10 @@
 import asyncio
+import re
 from datetime import datetime
 from typing import Optional, Union
 
 import discord
 from discord.ext import commands
-
-import re
 
 from dateutil import parser
 from natural.date import duration
@@ -708,9 +707,9 @@ class Modmail:
             reason = after.arg
             if reason.startswith('System Message: '):
                 raise commands.UserInputError
-            elif re.search(r'%(.+?)%$', reason) is not None:
+            if re.search(r'%(.+?)%$', reason) is not None:
                 raise commands.UserInputError
-            elif after.dt > after.now:
+            if after.dt > after.now:
                 reason = f'{reason} %{after.dt.isoformat()}%'
 
         if not reason:

--- a/cogs/plugins.py
+++ b/cogs/plugins.py
@@ -9,7 +9,8 @@ import sys
 
 from discord.ext import commands
 
-from core.models import Bot
+from core import checks
+from core.models import Bot, PermissionLevel
 from core.utils import info, error
 
 logger = logging.getLogger('Modmail')
@@ -113,15 +114,15 @@ class Plugins:
             msg = f'Loaded plugins.{username}-{repo}.{plugin_name}'
             logger.info(info(msg))
 
-    @commands.group(aliases=['plugins'])
-    @commands.is_owner()
+    @commands.group(aliases=['plugins'], invoke_without_command=True)
+    @checks.has_permissions(PermissionLevel.OWNER)
     async def plugin(self, ctx):
         """Plugin handler. Controls the plugins in the bot."""
-        if ctx.invoked_subcommand is None:
-            cmd = self.bot.get_command('help')
-            await ctx.invoke(cmd, command='plugin')
+        cmd = self.bot.get_command('help')
+        await ctx.invoke(cmd, command='plugin')
 
     @plugin.command()
+    @checks.has_permissions(PermissionLevel.OWNER)
     async def add(self, ctx, *, plugin_name):
         """Adds a plugin"""
         if plugin_name in self.bot.config.plugins:
@@ -161,6 +162,7 @@ class Plugins:
                                    'Use username/repo/plugin.')
 
     @plugin.command()
+    @checks.has_permissions(PermissionLevel.OWNER)
     async def remove(self, ctx, *, plugin_name):
         """Removes a certain plugin"""
         if plugin_name in self.bot.config.plugins:
@@ -195,6 +197,7 @@ class Plugins:
             await ctx.send('Plugin not installed.')
 
     @plugin.command()
+    @checks.has_permissions(PermissionLevel.OWNER)
     async def update(self, ctx, *, plugin_name):
         """Updates a certain plugin"""
         if plugin_name not in self.bot.config.plugins:
@@ -227,6 +230,7 @@ class Plugins:
                         await ctx.send(f'Unable to start plugin: `{exc}`')
 
     @plugin.command(name='list')
+    @checks.has_permissions(PermissionLevel.OWNER)
     async def list_(self, ctx):
         """Shows a list of currently enabled plugins"""
         if self.bot.config.plugins:

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -883,7 +883,7 @@ class Utility:
 
     @add_perms.command(name='command')
     @checks.has_permissions(PermissionLevel.OWNER)
-    async def add_perms_command(self, ctx, command: str, user_or_role: Union[User, str]):
+    async def add_perms_command(self, ctx, *, command: str, user_or_role: Union[User, str]):
         """Add a user, role, or everyone permission to use a command."""
         if command not in self.bot.all_commands:
             embed = Embed(
@@ -912,7 +912,7 @@ class Utility:
 
     @add_perms.command(name='level', aliases=['group'])
     @checks.has_permissions(PermissionLevel.OWNER)
-    async def add_perms_level(self, ctx, level: str, user_or_role: Union[User, str]):
+    async def add_perms_level(self, ctx, *, level: str, user_or_role: Union[User, str]):
         """Add a user, role, or everyone permission to use commands of a permission level."""
         if level.upper() not in PermissionLevel._member_names_:
             embed = Embed(
@@ -949,7 +949,7 @@ class Utility:
 
     @remove_perms.command(name='command')
     @checks.has_permissions(PermissionLevel.OWNER)
-    async def remove_perms_command(self, ctx, command: str, user_or_role: Union[User, str]):
+    async def remove_perms_command(self, ctx, *, command: str, user_or_role: Union[User, str]):
         """Remove a user, role, or everyone permission to use a command."""
         if command not in self.bot.all_commands:
             embed = Embed(
@@ -978,7 +978,7 @@ class Utility:
 
     @remove_perms.command(name='level', aliases=['group'])
     @checks.has_permissions(PermissionLevel.OWNER)
-    async def remove_perms_level(self, ctx, level: str, user_or_role: Union[User, str]):
+    async def remove_perms_level(self, ctx, *, level: str, user_or_role: Union[User, str]):
         """Remove a user, role, or everyone permission to use commands of a permission level."""
         if level.upper() not in PermissionLevel._member_names_:
             embed = Embed(
@@ -1014,7 +1014,7 @@ class Utility:
 
     @get_perms.command(name='command')
     @checks.has_permissions(PermissionLevel.OWNER)
-    async def get_perms_command(self, ctx, command: str):
+    async def get_perms_command(self, ctx, *, command: str):
         """View the currently-set permissions for a command."""
         if command not in self.bot.all_commands:
             embed = Embed(
@@ -1050,7 +1050,7 @@ class Utility:
 
     @get_perms.command(name='level', aliases=['group'])
     @checks.has_permissions(PermissionLevel.OWNER)
-    async def get_perms_level(self, ctx, level: str):
+    async def get_perms_level(self, ctx, *, level: str):
         """View the currently-set permissions for commands of a permission level."""
         if level.upper() not in PermissionLevel._member_names_:
             embed = Embed(
@@ -1086,7 +1086,7 @@ class Utility:
 
     @commands.command(hidden=True, name='eval')
     @checks.has_permissions(PermissionLevel.OWNER)
-    async def eval_(self, ctx, *, body):
+    async def eval_(self, ctx, *, body: str):
         """Evaluates Python code"""
 
         env = {

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -442,9 +442,9 @@ class Utility:
             raise commands.UserInputError
 
         activity, msg = (await self.set_presence(
-                activity_identifier=activity_type,
-                activity_by_key=True,
-                activity_message=message
+            activity_identifier=activity_type,
+            activity_by_key=True,
+            activity_message=message
          ))['activity']
         if activity is None:
             raise commands.UserInputError
@@ -488,8 +488,8 @@ class Utility:
         status_type = status_type.replace(' ', '_')
 
         status, msg = (await self.set_presence(
-                status_identifier=status_type,
-                status_by_key=True
+            status_identifier=status_type,
+            status_by_key=True
         ))['status']
         if status is None:
             raise commands.UserInputError

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -45,7 +45,7 @@ class Utility:
                 new_fmt = f'`{prefix + cmd.qualified_name}` '
                 perm_level = next(getattr(c, 'permission_level', None) for c in cmd.checks)
                 if perm_level is not None:
-                    new_fmt += f'[{perm_level}] '
+                    new_fmt = f'`[{perm_level}] {prefix + cmd.qualified_name}` '
 
                 new_fmt += f'- {cmd.short_doc}\n'
                 if len(new_fmt) + len(fmts[-1]) >= 1024:
@@ -80,12 +80,15 @@ class Utility:
         prefix = self.bot.prefix
 
         perm_level = next(getattr(c, 'permission_level', None) for c in cmd.checks)
-        perm_level = f' [{perm_level}]' if perm_level is not None else ''
+        perm_level = f'**{perm_level.name}** [{perm_level}]' if perm_level is not None else ''
+
         embed = Embed(
-            title=f'`{prefix}{cmd.signature}`{perm_level}',
+            title=f'`{prefix}{cmd.signature}`',
             color=self.bot.main_color,
             description=cmd.help
         )
+        
+        embed.add_field(name='Permission level', value=perm_level)
 
         if not isinstance(cmd, commands.Group):
             return embed

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -87,8 +87,7 @@ class Utility:
             color=self.bot.main_color,
             description=cmd.help
         )
-        
-        
+                
 
         if not isinstance(cmd, commands.Group):
             embed.set_footer(text=f'Permission level: {perm_level}')
@@ -1053,7 +1052,8 @@ class Utility:
             if not permissions:
                 embed = Embed(
                     title=f'Permission entries for command `{cmd.name}`:',
-                    description='No permission entries found.'
+                    description='No permission entries found.',
+                    color=self.bot.main_color,
                 )
             else:
                 values = []
@@ -1077,7 +1077,8 @@ class Utility:
 
                 embed = Embed(
                     title=f'Permission entries for command `{cmd.name}`:',
-                    description=', '.join(values)
+                    description=', '.join(values),
+                    color=self.bot.main_color
                 )
             return embed
 
@@ -1110,7 +1111,8 @@ class Utility:
                 embed = Embed(
                     title='Permission entries for permission '
                           f'level `{perm_level.name}`:',
-                    description='No permission entries found.'
+                    description='No permission entries found.',
+                    color=self.bot.main_color,
                 )
             else:
                 values = []
@@ -1134,7 +1136,8 @@ class Utility:
 
                 embed = Embed(
                     title=f'Permission entries for permission level `{perm_level.name}`:',
-                    description=', '.join(values)
+                    description=', '.join(values),
+                    color=self.bot.main_color,
                 )
             return embed
 

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -1075,7 +1075,7 @@ class Utility:
                 f'to does not exist: `{level}`.'
             )
             return await ctx.send(embed=embed)
-        permissions = self.bot.config.command_permissions.get(PermissionLevel[level.upper()].name)
+        permissions = self.bot.config.level_permissions.get(PermissionLevel[level.upper()].name)
         if permissions is None or not permissions:
             embed = Embed(
                 title=f'Permission entries for permission level `{level}`:',

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -445,7 +445,7 @@ class Utility:
             activity_identifier=activity_type,
             activity_by_key=True,
             activity_message=message
-         ))['activity']
+        ))['activity']
         if activity is None:
             raise commands.UserInputError
 

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -80,7 +80,7 @@ class Utility:
         prefix = self.bot.prefix
 
         perm_level = next(getattr(c, 'permission_level', None) for c in cmd.checks)
-        perm_level = f'**{perm_level.name}** [{perm_level}]' if perm_level is not None else ''
+        perm_level = f'{perm_level.name} [{perm_level}]' if perm_level is not None else ''
 
         embed = Embed(
             title=f'`{prefix}{cmd.signature}`',
@@ -88,10 +88,13 @@ class Utility:
             description=cmd.help
         )
         
-        embed.add_field(name='Permission level', value=perm_level)
+        
 
         if not isinstance(cmd, commands.Group):
+            embed.set_footer(text=f'Permission level: {perm_level}')
             return embed
+        
+        embed.add_field(name='Permission level', value=perm_level)
 
         fmt = ''
         length = len(cmd.commands)

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -899,7 +899,7 @@ class Utility:
         elif user_or_role in {'everyone', 'all'}:
             value = -1
         else:
-            raise commands.CommandInvokeError('Invalid user or role.')
+            raise commands.UserInputError('Invalid user or role.')
 
         await self.bot.update_perms(self.bot.all_commands[command].name, value)
         embed = Embed(
@@ -927,7 +927,7 @@ class Utility:
         elif user_or_role in {'everyone', 'all'}:
             value = -1
         else:
-            raise commands.CommandInvokeError('Invalid user or role.')
+            raise commands.UserInputError('Invalid user or role.')
 
         await self.bot.update_perms(PermissionLevel[level.upper()], value)
         embed = Embed(
@@ -963,7 +963,7 @@ class Utility:
         elif user_or_role in {'everyone', 'all'}:
             value = -1
         else:
-            raise commands.CommandInvokeError('Invalid user or role.')
+            raise commands.UserInputError('Invalid user or role.')
 
         await self.bot.update_perms(self.bot.all_commands[command].name, value, add=False)
         embed = Embed(
@@ -991,7 +991,7 @@ class Utility:
         elif user_or_role in {'everyone', 'all'}:
             value = -1
         else:
-            raise commands.CommandInvokeError('Invalid user or role.')
+            raise commands.UserInputError('Invalid user or role.')
 
         await self.bot.update_perms(PermissionLevel[level.upper()], value, add=False)
         embed = Embed(
@@ -1011,7 +1011,7 @@ class Utility:
         elif user_or_role in {'everyone', 'all'}:
             value = -1
         else:
-            raise commands.CommandInvokeError('Invalid user or role.')
+            raise commands.UserInputError('Invalid user or role.')
 
         cmds = []
         levels = []

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -883,7 +883,7 @@ class Utility:
 
     @add_perms.command(name='command')
     @checks.has_permissions(PermissionLevel.OWNER)
-    async def add_perms_command(self, ctx, command: str, user_or_role: Union[User, str]):
+    async def add_perms_command(self, ctx, command: str, *, user_or_role: Union[User, str]):
         """Add a user, role, or everyone permission to use a command."""
         if command not in self.bot.all_commands:
             embed = Embed(
@@ -912,7 +912,7 @@ class Utility:
 
     @add_perms.command(name='level', aliases=['group'])
     @checks.has_permissions(PermissionLevel.OWNER)
-    async def add_perms_level(self, ctx, level: str, user_or_role: Union[User, str]):
+    async def add_perms_level(self, ctx, level: str, *, user_or_role: Union[User, str]):
         """Add a user, role, or everyone permission to use commands of a permission level."""
         if level.upper() not in PermissionLevel._member_names_:
             embed = Embed(
@@ -949,7 +949,7 @@ class Utility:
 
     @remove_perms.command(name='command')
     @checks.has_permissions(PermissionLevel.OWNER)
-    async def remove_perms_command(self, ctx, command: str, user_or_role: Union[User, str]):
+    async def remove_perms_command(self, ctx, command: str, *, user_or_role: Union[User, str]):
         """Remove a user, role, or everyone permission to use a command."""
         if command not in self.bot.all_commands:
             embed = Embed(
@@ -978,7 +978,7 @@ class Utility:
 
     @remove_perms.command(name='level', aliases=['group'])
     @checks.has_permissions(PermissionLevel.OWNER)
-    async def remove_perms_level(self, ctx, level: str, user_or_role: Union[User, str]):
+    async def remove_perms_level(self, ctx, level: str, *, user_or_role: Union[User, str]):
         """Remove a user, role, or everyone permission to use commands of a permission level."""
         if level.upper() not in PermissionLevel._member_names_:
             embed = Embed(

--- a/core/checks.py
+++ b/core/checks.py
@@ -1,4 +1,8 @@
+import logging
 from discord.ext import commands
+from core.utils import error
+
+logger = logging.getLogger('Modmail')
 
 
 def has_permissions(**perms):
@@ -33,11 +37,17 @@ def has_permissions(**perms):
 
         resolved = ctx.channel.permissions_for(ctx.author)
 
-        return resolved.administrator or all(
+        has_perm = resolved.administrator or all(
             getattr(resolved, name, None) == value
             for name, value in perms.items()
         )
 
+        if not has_perm:
+            restrictions = ', '.join(f'{name.replace("_", " ").title()} ({"yes" if value else "no"})'
+                                     for name, value in perms.items())
+            logger.error(error(f'Command `{ctx.command.qualified_name}` processes '
+                               f'the following restrictions(s): {restrictions}.'))
+        return has_perm
     return commands.check(predicate)
 
 

--- a/core/checks.py
+++ b/core/checks.py
@@ -37,7 +37,7 @@ def has_permissions(permission_level: PermissionLevel = PermissionLevel.REGULAR)
     return commands.check(predicate)
 
 
-async def check_permissions(ctx: commands.Context, 
+async def check_permissions(ctx: commands.Context,
                             command_name: str,
                             permission_level: PermissionLevel) -> bool:
     if await ctx.bot.is_owner(ctx.author):

--- a/core/checks.py
+++ b/core/checks.py
@@ -34,6 +34,8 @@ def has_permissions(permission_level: PermissionLevel = PermissionLevel.REGULAR)
             logger.error(error(f'You does not have permission to use this command: '
                                f'`{ctx.command.qualified_name}` ({permission_level.name}).'))
         return has_perm
+
+    predicate.permission_level = permission_level
     return commands.check(predicate)
 
 

--- a/core/checks.py
+++ b/core/checks.py
@@ -1,54 +1,76 @@
 import logging
+
 from discord.ext import commands
+
+from core.models import PermissionLevel
 from core.utils import error
 
 logger = logging.getLogger('Modmail')
 
 
-def has_permissions(**perms):
+def has_permissions(permission_level: PermissionLevel = PermissionLevel.REGULAR):
     """
     A decorator that checks if the author has the required permissions.
+
+    Parameters
+    ----------
+
+    permission_level : PermissionLevel
+        The lowest level of permission needed to use this command.
+        Defaults to REGULAR.
 
     Examples
     --------
     ::
-        @has_permissions(administrator=True)
+        @has_permissions(PermissionLevel.OWNER)
         async def setup(ctx):
             print("Success")
     """
 
     async def predicate(ctx):
-        """
-        Parameters
-        ----------
-        ctx : Context
-            The current discord.py `Context`.
+        has_perm = await check_permissions(ctx, ctx.command.qualified_name, permission_level)
 
-        Returns
-        -------
-        bool
-            `True` if the author is a bot owner, or
-            has the ``administrator`` permission.
-            Or if the author has all of the required permissions.
-            Otherwise, `False`.
-        """
-        if await ctx.bot.is_owner(ctx.author):
-            return True
-
-        resolved = ctx.channel.permissions_for(ctx.author)
-
-        has_perm = resolved.administrator or all(
-            getattr(resolved, name, None) == value
-            for name, value in perms.items()
-        )
-
-        if not has_perm:
-            restrictions = ', '.join(f'{name.replace("_", " ").title()} ({"yes" if value else "no"})'
-                                     for name, value in perms.items())
-            logger.error(error(f'Command `{ctx.command.qualified_name}` processes '
-                               f'the following restrictions(s): {restrictions}.'))
+        if not has_perm and ctx.command.qualified_name != 'help':
+            logger.error(error(f'You does not have permission to use this command: '
+                               f'`{ctx.command.qualified_name}` ({permission_level.name}).'))
         return has_perm
     return commands.check(predicate)
+
+
+async def check_permissions(ctx: commands.Context, 
+                            command_name: str,
+                            permission_level: PermissionLevel) -> bool:
+    if await ctx.bot.is_owner(ctx.author):
+        # Direct bot owner (creator) has absolute power over the bot
+        return True
+
+    if permission_level != PermissionLevel.OWNER and ctx.channel.permissions_for(ctx.author).administrator:
+        # Administrators have permission to all non-owner commands
+        return True
+
+    command_permissions = ctx.bot.config.command_permissions
+    author_roles = ctx.author.roles
+
+    if command_name in command_permissions:
+        # -1 is for @everyone
+        if -1 in command_permissions[command_name]:
+            return True
+        has_perm_role = any(role.id in command_permissions[command_name] for role in author_roles)
+        has_perm_id = ctx.author.id in command_permissions[command_name]
+        return has_perm_role or has_perm_id
+
+    level_permissions = ctx.bot.config.level_permissions
+
+    for level in PermissionLevel:
+        if level >= permission_level and level.name in level_permissions:
+            if -1 in level_permissions[level.name]:
+                return True
+            has_perm_role = any(role.id in level_permissions[level.name] for role in author_roles)
+            has_perm_id = ctx.author.id in level_permissions[level.name]
+            if has_perm_role or has_perm_id:
+                return True
+
+    return False
 
 
 def thread_only():

--- a/core/config.py
+++ b/core/config.py
@@ -19,7 +19,7 @@ class ConfigManager(ConfigManagerABC):
 
         # bot settings
         'main_category_id', 'disable_autoupdates', 'prefix', 'mention',
-        'main_color', 'user_typing', 'mod_typing', 'account_age', 
+        'main_color', 'user_typing', 'mod_typing', 'account_age', 'reply_without_command',
 
         # logging
         'log_channel_id',

--- a/core/config.py
+++ b/core/config.py
@@ -42,7 +42,7 @@ class ConfigManager(ConfigManagerABC):
         'activity_message', 'activity_type', 'status',
 
         # moderation
-        'blocked',
+        'blocked', 'command_permissions', 'level_permissions',
 
         # threads
         'snippets', 'notification_squad', 'subscriptions', 'closures',
@@ -53,7 +53,7 @@ class ConfigManager(ConfigManagerABC):
 
     protected_keys = {
         # Modmail
-        'modmail_api_token', 'modmail_guild_id', 'guild_id', 'owners',
+        'modmail_api_token', 'modmail_guild_id', 'guild_id',
         'log_url', 'mongo_uri',
 
         # bot
@@ -107,6 +107,8 @@ class ConfigManager(ConfigManagerABC):
             'plugins': [],
             'aliases': {},
             'blocked': {},
+            'command_permissions': {},
+            'level_permissions': {},
             'notification_squad': {},
             'subscriptions': {},
             'closures': {},

--- a/core/config.py
+++ b/core/config.py
@@ -29,7 +29,7 @@ class ConfigManager(ConfigManagerABC):
         'thread_creation_response', 'thread_creation_footer', 'thread_creation_title',
         'thread_close_footer', 'thread_close_title', 'thread_close_response',
         'thread_self_close_response',
-        
+
         # moderation
         'recipient_color', 'mod_tag', 'mod_color',
 

--- a/core/models.py
+++ b/core/models.py
@@ -2,6 +2,7 @@ import abc
 import asyncio
 import typing
 from datetime import datetime
+from enum import IntEnum
 
 from discord import Color, Member, User, CategoryChannel, DMChannel, Embed
 from discord import Message, TextChannel, Guild
@@ -9,6 +10,14 @@ from discord.ext import commands
 
 from aiohttp import ClientSession
 from motor.motor_asyncio import AsyncIOMotorClient
+
+
+class PermissionLevel(IntEnum):
+    OWNER = 5
+    ADMINISTRATOR = 4
+    MODERATOR = 3
+    SUPPORTER = 2
+    REGULAR = 1
 
 
 class Bot(abc.ABC, commands.Bot):
@@ -142,6 +151,11 @@ class Bot(abc.ABC, commands.Bot):
 
     @abc.abstractmethod
     async def convert_emoji(self, name: str) -> str:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def update_perms(self, name: typing.Union[PermissionLevel, str],
+                           value: int, add: bool = True) -> None:
         raise NotImplementedError
 
     @staticmethod
@@ -380,7 +394,8 @@ class ThreadManagerABC(abc.ABC):
     @abc.abstractmethod
     async def find(self, *,
                    recipient: typing.Union[Member, User] = None,
-                   channel: TextChannel = None) -> \
+                   channel: TextChannel = None,
+                   recipient_id: int = None) -> \
             typing.Optional['ThreadABC']:
         raise NotImplementedError
 

--- a/core/models.py
+++ b/core/models.py
@@ -15,7 +15,9 @@ from motor.motor_asyncio import AsyncIOMotorClient
 class PermissionLevel(IntEnum):
     OWNER = 5
     ADMINISTRATOR = 4
+    ADMIN = 4
     MODERATOR = 3
+    MOD = 3
     SUPPORTER = 2
     REGULAR = 1
 

--- a/core/thread.py
+++ b/core/thread.py
@@ -587,22 +587,26 @@ class ThreadManager(ThreadManagerABC):
     def __getitem__(self, item):
         return self.cache[item]
 
-    async def find(self, *, recipient=None, channel=None):
+    async def find(self, *, recipient=None, channel=None, recipient_id=None):
         """Finds a thread from cache or from discord channel topics."""
         if recipient is None and channel is not None:
             return await self._find_from_channel(channel)
 
         thread = None
+
+        if recipient:
+            recipient_id = recipient.id
+
         try:
-            thread = self.cache[recipient.id]
+            thread = self.cache[recipient_id]
         except KeyError:
             channel = discord.utils.get(
                 self.bot.modmail_guild.text_channels,
-                topic=f'User ID: {recipient.id}'
+                topic=f'User ID: {recipient_id}'
             )
             if channel:
                 thread = Thread(self, recipient, channel)
-                self.cache[recipient.id] = thread
+                self.cache[recipient_id] = thread
                 thread.ready = True
         return thread
 

--- a/core/thread.py
+++ b/core/thread.py
@@ -627,6 +627,8 @@ class ThreadManager(ThreadManagerABC):
         elif channel.topic is None:
             try:
                 async for message in channel.history(limit=100):
+                    if message.author != self.bot.user:
+                        continue
                     if message.embeds:
                         embed = message.embeds[0]
                         if embed.footer.text:

--- a/core/thread.py
+++ b/core/thread.py
@@ -482,7 +482,7 @@ class Thread(ThreadABC):
             ):
                 embed.set_image(url=att[0])
                 if att[1]:
-                    embed.add_field(name='Image', value=f'[**{att[1]}**]({att[0]})')
+                    embed.add_field(name='Image', value=f'[{att[1]}]({att[0]})')
                 embedded_image = True
             elif att[1] is not None:
                 if note:

--- a/core/thread.py
+++ b/core/thread.py
@@ -12,7 +12,6 @@ from core.models import Bot, ThreadManagerABC, ThreadABC
 from core.utils import is_image_url, days, match_user_id
 from core.utils import truncate, ignore, error
 
-
 logger = logging.getLogger('Modmail')
 
 
@@ -104,12 +103,12 @@ class Thread(ThreadABC):
         try:
             log_url, log_data = await asyncio.gather(
                 self.bot.api.create_log_entry(recipient, channel,
-                                            creator or recipient),
+                                              creator or recipient),
                 self.bot.api.get_user_logs(recipient.id)
             )
 
             log_count = sum(1 for log in log_data if not log['open'])
-        except: # Something went wrong with database?
+        except:  # Something went wrong with database?
             log_url = log_count = None
             # ensure core functionality still works
 
@@ -153,14 +152,15 @@ class Thread(ThreadABC):
 
         footer = self.bot.config.get('thread_creation_footer', footer)
         embed.set_footer(text=footer, icon_url=self.bot.guild.icon_url)
-        embed.title = self.bot.config.get('thread_creation_title', 'Thread Created')
+        embed.title = self.bot.config.get('thread_creation_title',
+                                          'Thread Created')
 
         if creator is None:
             msg = await recipient.send(embed=embed)
             if not self.bot.config.get('disable_recipient_thread_close'):
                 close_emoji = self.bot.config.get('close_emoji', '🔒')
                 close_emoji = await self.bot.convert_emoji(close_emoji)
-                await msg.add_reaction(close_emoji) 
+                await msg.add_reaction(close_emoji)
 
     def _close_after(self, closer, silent, delete_channel, message):
         return self.bot.loop.create_task(
@@ -245,7 +245,7 @@ class Thread(ThreadABC):
             user = f"{self.recipient} (`{self.id}`)"
         else:
             user = f'`{self.id}`'
-        
+
         if self.id == closer.id:
             _closer = 'the Recipient'
         else:
@@ -261,7 +261,7 @@ class Thread(ThreadABC):
         tasks = [
             self.bot.config.update()
         ]
-        
+
         try:
             tasks.append(self.bot.log_channel.send(embed=embed))
         except (ValueError, AttributeError):
@@ -269,26 +269,29 @@ class Thread(ThreadABC):
 
         # Thread closed message
 
-        embed = discord.Embed(title=self.bot.config.get('thread_close_title', 'Thread Closed'),
-                              color=discord.Color.red(),
-                              timestamp=datetime.utcnow())
+        embed = discord.Embed(
+            title=self.bot.config.get('thread_close_title', 'Thread Closed'),
+            color=discord.Color.red(),
+            timestamp=datetime.utcnow())
 
         if not message:
             if self.id == closer.id:
                 message = self.bot.config.get(
-                    'thread_self_close_response', 
+                    'thread_self_close_response',
                     'You have closed this Modmail thread.'
-                    )
+                )
             else:
                 message = self.bot.config.get(
                     'thread_close_response',
                     '{closer.mention} has closed this Modmail thread.'
-                    )
-            
-        message = message.format(closer=closer, loglink=log_url, logkey=log_data['key'])
+                )
+
+        message = message.format(closer=closer, loglink=log_url,
+                                 logkey=log_data['key'])
 
         embed.description = message
-        footer = self.bot.config.get('thread_close_footer', 'Replying will create a new thread')
+        footer = self.bot.config.get('thread_close_footer',
+                                     'Replying will create a new thread')
         embed.set_footer(text=footer,
                          icon_url=self.bot.guild.icon_url)
 
@@ -476,13 +479,12 @@ class Thread(ThreadABC):
 
         for att in images:
             if not prioritize_uploads or (
-                    is_image_url(*att) and not
-                    embedded_image and
-                    att[1]
+                    is_image_url(*att) and not embedded_image and att[1]
             ):
                 embed.set_image(url=att[0])
                 if att[1]:
-                    embed.add_field(name='Image', value=f'[{att[1]}]({att[0]})')
+                    embed.add_field(name='Image',
+                                    value=f'[{att[1]}]({att[0]})')
                 embedded_image = True
             elif att[1] is not None:
                 if note:


### PR DESCRIPTION
Resolves #196 and resolves #165

# v2.18.0


### What's new?

- A brand new permission system! Replacing the old guild-based permissions (ie. manage channels, manage messages), the new system enables you to customize your desired permission level specific to a command or a group of commands for a role or user.
- There are five permission groups/levels:
  - Owner
  - Administrator
  - Moderator
  - Supporter
  - Regular

You may add a role or user to a permission group through any of the following methods:
- `?permissions add level owner @role`
- `?permissions add level supporter member-name`
- `?permissions add level moderator everyone`
- `?permissions add level moderator @member#1234`
- `?permissions add level administrator 78912384930291853`

The same applies to individual commands permissions:
- `?permissions add command-name @member#1234`
- ... and the other methods listed above.

To revoke permission, use `remove` instead of `add`.

To view all roles and users with permission for a permission group or command do:
-  `?permissions get command command-name`
-  `?permissions get level owner`

### Note

When updating to this version, all prior permission settings with guild-based permissions will be invalidated. You will need to convert to the above system.

Check the changelog for the most up-to-date changes.