### PR TITLE
Mutual guilds field and pinned notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# v2.23.0
+
+### Added 
+
+Added a "Mutual servers" field to the genesis embed if:
+a) The user is not in the main guild.
+b) The user shares more than 1 server with the bot.
+
+### Changed
+
+Notes taken using the `?note` command are now automatically pinned within the thread channel.
+
 # v2.22.0
 
 ### Added

--- a/bot.py
+++ b/bot.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-__version__ = "2.22.0"
+__version__ = "2.23.0"
 
 import asyncio
 import logging

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -655,7 +655,8 @@ class Modmail(commands.Cog):
         """
         ctx.message.content = msg
         async with ctx.typing():
-            await ctx.thread.note(ctx.message)
+            msg = await ctx.thread.note(ctx.message)
+            await msg.pin()
 
     async def find_linked_message(self, ctx, message_id):
         linked_message_id = None

--- a/core/thread.py
+++ b/core/thread.py
@@ -364,10 +364,12 @@ class Thread:
         if not message.content and not message.attachments:
             raise MissingRequiredArgument(param(name="msg"))
 
-        await asyncio.gather(
+        _, msg = await asyncio.gather(
             self.bot.api.append_log(message, self.channel.id, type_="system"),
             self.send(message, self.channel, note=True),
         )
+
+        return msg
 
     async def reply(self, message: discord.Message, anonymous: bool = False) -> None:
         if not message.content and not message.attachments:
@@ -579,7 +581,8 @@ class Thread:
         else:
             mentions = None
 
-        await destination.send(mentions, embed=embed)
+        _msg = await destination.send(mentions, embed=embed)
+
         if additional_images:
             self.ready = False
             await asyncio.gather(*additional_images)
@@ -587,6 +590,8 @@ class Thread:
 
         if delete_message:
             self.bot.loop.create_task(ignore(message.delete()))
+
+        return _msg
 
     def get_notifications(self) -> str:
         config = self.bot.config
@@ -791,9 +796,7 @@ class ThreadManager:
             if role_names:
                 embed.add_field(name="Roles", value=role_names, inline=True)
         else:
-            embed.set_footer(
-                text=f"{footer} • (not in main server)"
-            )
+            embed.set_footer(text=f"{footer} • (not in main server)")
 
         if log_count:
             # embed.add_field(name='Past logs', value=f'{log_count}')

--- a/core/thread.py
+++ b/core/thread.py
@@ -792,7 +792,7 @@ class ThreadManager:
                 embed.add_field(name="Roles", value=role_names, inline=True)
         else:
             embed.set_footer(
-                text=f"{footer} • user not in main server"
+                text=f"{footer} • (Not in main server)"
             )
 
         if log_count:

--- a/core/thread.py
+++ b/core/thread.py
@@ -803,7 +803,7 @@ class ThreadManager:
             embed.description += "."
 
         mutual_guilds = [g for g in self.bot.guilds if user in g.members]
-        if user not in self.bot.modmail_guild.members or len(mutual_guilds) > 1:
+        if user not in self.bot.guild.members or len(mutual_guilds) > 1:
             embed.add_field(
                 name="Mutual Servers", value=", ".join(g.name for g in mutual_guilds)
             )

--- a/core/thread.py
+++ b/core/thread.py
@@ -120,10 +120,6 @@ class Thread:
             log_url = log_count = None
             # ensure core functionality still works
 
-        info_embed = self.manager.format_info_embed(
-            recipient, log_url, log_count, discord.Color.green()
-        )
-
         topic = f"User ID: {recipient.id}"
         if creator:
             mention = None
@@ -131,11 +127,14 @@ class Thread:
             mention = self.bot.config.get("mention", "@here")
 
         async def send_genesis_message():
+            info_embed = self.manager.format_info_embed(
+                recipient, log_url, log_count, discord.Color.green()
+            )
             try:
                 msg = await channel.send(mention, embed=info_embed)
                 self.bot.loop.create_task(msg.pin())
                 self.genesis_message = msg
-            except:
+            except Exception as e:
                 pass
             finally:
                 self.ready = True

--- a/core/thread.py
+++ b/core/thread.py
@@ -792,7 +792,7 @@ class ThreadManager:
                 embed.add_field(name="Roles", value=role_names, inline=True)
         else:
             embed.set_footer(
-                text=f"{footer} | Note: this member is not part of the main server."
+                text=f"{footer} • user not in main server"
             )
 
         if log_count:

--- a/core/thread.py
+++ b/core/thread.py
@@ -792,7 +792,7 @@ class ThreadManager:
                 embed.add_field(name="Roles", value=role_names, inline=True)
         else:
             embed.set_footer(
-                text=f"{footer} • (Not in main server)"
+                text=f"{footer} • (not in main server)"
             )
 
         if log_count:

--- a/core/thread.py
+++ b/core/thread.py
@@ -803,8 +803,8 @@ class ThreadManager:
         else:
             embed.description += "."
 
-        mutual_guilds = [g for g in self.bot.guilds if user in g]
-        if user not in self.bot.modmail_guild or len(mutual_guilds) > 1:
+        mutual_guilds = [g for g in self.bot.guilds if user in g.members]
+        if user not in self.bot.modmail_guild.members or len(mutual_guilds) > 1:
             embed.add_field(
                 name="Mutual Servers", value=", ".join(g.name for g in mutual_guilds)
             )

--- a/core/thread.py
+++ b/core/thread.py
@@ -793,7 +793,7 @@ class ThreadManager:
                 embed.add_field(name="Roles", value=role_names, inline=True)
         else:
             embed.set_footer(
-                text=f"{footer} | Note: this member " "is not part of this server."
+                text=f"{footer} | Note: this member is not part of the main server."
             )
 
         if log_count:
@@ -802,5 +802,11 @@ class ThreadManager:
             embed.description += f" with **{log_count}** past {thread}."
         else:
             embed.description += "."
+
+        mutual_guilds = [g for g in self.bot.guilds if user in g]
+        if user not in self.bot.modmail_guild or len(mutual_guilds) > 1:
+            embed.add_field(
+                name="Mutual Servers", value=", ".join(g.name for g in mutual_guilds)
+            )
 
         return embed


### PR DESCRIPTION
Adds a "Mutual servers" field to the genesis embed if:
  a) The user is not in the main guild.
  b) The user shares more than 1 server with the bot.

This resolves #259

This pr also implements pinning notes using the `?note` command.

