### PR TITLE
Fix Typo in Snippet Help Dialogue

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -96,7 +96,7 @@ class Modmail(commands.Cog):
         To use snippets:
 
         First create a snippet using:
-        - `{prefix}snippet add snippet-name A pre-defined text.`
+        - `{prefix}snippets add snippet-name A pre-defined text.`
 
         Afterwards, you can use your snippet in a thread channel
         with `{prefix}snippet-name`, the message "A pre-defined text."


### PR DESCRIPTION
Change the template command in the help dialogue to create a snippet. (Line 99)
