### PR TITLE
Set presence every 10 mins

### DIFF
--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -683,7 +683,7 @@ class Utility(commands.Cog):
         await self.bot.wait_until_ready()
         while not self.bot.is_closed():
             self.presence = await self.set_presence()
-            await asyncio.sleep(3600)
+            await asyncio.sleep(600)
 
     @commands.command()
     @checks.has_permissions(PermissionLevel.ADMINISTRATOR)


### PR DESCRIPTION
According to d.py support, the disappearance of presence is common among all discord bots and is likely a bug on discord's side. This will reduce resetting of the presence to 10 mins.

![Discord Presence Bug](https://i.imgur.com/x4l8NBL.png)

Sources:
https://discordapp.com/channels/336642139381301249/381965515721146390/591864012376113163