### PR TITLE
This introduces `thread_auto_close` and `thread_auto_close_response`.…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added 
 
 - Sponsors command that will list sponsors.
+- Threads will close automatically after some time when `thread_auto_close` is set.
+- Custom closing message can be set with `thread_auto_close_response`. 
+
 
 ### Changed
 - Channel names now can contain unicode characters.

--- a/core/config.py
+++ b/core/config.py
@@ -35,6 +35,8 @@ class ConfigManager:
         "blocked_emoji",
         "close_emoji",
         "disable_recipient_thread_close",
+        "thread_auto_close",
+        "thread_auto_close_response",
         "thread_creation_response",
         "thread_creation_footer",
         "thread_creation_title",
@@ -89,7 +91,7 @@ class ConfigManager:
 
     colors = {"mod_color", "recipient_color", "main_color"}
 
-    time_deltas = {"account_age", "guild_age"}
+    time_deltas = {"account_age", "guild_age", "thread_auto_close"}
 
     valid_keys = allowed_to_change_in_command | internal_keys | protected_keys
 

--- a/core/thread.py
+++ b/core/thread.py
@@ -1,15 +1,17 @@
 import asyncio
 import logging
-import re
 import os
+import re
 import string
 import typing
-from types import SimpleNamespace as param
 from datetime import datetime, timedelta
+from types import SimpleNamespace as param
 
 import discord
+import isodate
 from discord.ext.commands import MissingRequiredArgument, CommandError
 
+from core.time import human_timedelta
 from core.utils import is_image_url, days, match_user_id
 from core.utils import truncate, ignore, error
 
@@ -39,6 +41,7 @@ class Thread:
         self.genesis_message = None
         self._ready_event = asyncio.Event()
         self._close_task = None
+        self._auto_close_task = None
 
     def __repr__(self):
         return (
@@ -218,6 +221,10 @@ class Thread:
 
         await self.cancel_closure()
 
+        # Cancel auto closing the thread if closed by any means.
+        if self._auto_close_task:
+            self._auto_close_task.cancel()
+
         if str(self.id) in self.bot.config.subscriptions:
             del self.bot.config.subscriptions[str(self.id)]
 
@@ -336,6 +343,72 @@ class Thread:
                 if str(message_id) == str(embed.author.url).split("/")[-1]:
                     return msg
 
+    async def _grab_timeout(
+            self
+    ) -> typing.Union[None, isodate.duration.Duration, timedelta]:
+        """
+        This grabs the timeout value for closing threads automatically
+        from the ConfigManager and parses it for use internally.
+
+        :returns: None if no timeout is set.
+        """
+        timeout = self.bot.config.get("thread_auto_close")
+        if timeout is None:
+            return timeout
+        else:
+            try:
+                timeout = isodate.parse_duration(timeout)
+            except isodate.ISO8601Error:
+                logger.warning(
+                    "The auto_close_thread limit needs to be a "
+                    "ISO-8601 duration formatted duration string "
+                    'greater than 0 days, not "%s".',
+                    str(timeout),
+                )
+                del self.bot.config.cache["thread_auto_close"]
+                await self.bot.config.update()
+                timeout = None
+        return timeout
+
+    async def _restart_close_timer(self):
+        """
+        This will create or restart a timer to automatically close this
+        thread.
+        """
+        timeout = await self._grab_timeout()
+
+        # Exit if timeout was not set
+        if timeout is None:
+            return
+
+        # Set timeout seconds
+        seconds = timeout.total_seconds()
+        # seconds = 20  # Uncomment to debug with just 20 seconds
+        reset_time = datetime.utcnow() + timedelta(seconds=seconds)
+        human_time = human_timedelta(dt=reset_time)
+
+        # Grab message
+        close_message = self.bot.config.get(
+            "thread_auto_close_response",
+            f"This thread has been closed automatically after no response from"
+            f" you for {human_time}."
+        )
+        time_marker_regex = "%t"
+        if len(re.findall(time_marker_regex, close_message)) == 1:
+            close_message = re.sub(time_marker_regex, str(human_time), close_message)
+        elif len(re.findall(time_marker_regex, close_message)) > 1:
+            logger.warning(
+                "The thread_auto_close_response should only contain one"
+                f" '{time_marker_regex}' to specify time."
+            )
+
+        if self._auto_close_task:
+            self._auto_close_task.cancel()
+        self._auto_close_task = self.bot.loop.call_later(
+            seconds, self._close_after, self.bot.user, False, True,
+            close_message
+        )
+
     async def edit_message(self, message_id: int, message: str) -> None:
         recipient_msg, channel_msg = await asyncio.gather(
             self._find_thread_message(self.recipient, message_id),
@@ -422,6 +495,8 @@ class Thread:
                 )
             )
 
+            await self._restart_close_timer()
+
         if self.close_task is not None:
             # Cancel closing if a thread message is sent.
             await self.cancel_closure()
@@ -463,6 +538,10 @@ class Thread:
 
         if not from_mod and not note:
             self.bot.loop.create_task(self.bot.api.append_log(message, self.channel.id))
+
+            # Cancel auto closing if we get a new message from user
+            if self._auto_close_task:
+                self._auto_close_task.cancel()
 
         destination = destination or self.channel
 

--- a/core/thread.py
+++ b/core/thread.py
@@ -343,9 +343,7 @@ class Thread:
                 if str(message_id) == str(embed.author.url).split("/")[-1]:
                     return msg
 
-    async def _grab_timeout(
-            self
-    ) -> typing.Union[None, isodate.duration.Duration, timedelta]:
+    async def _fetch_timeout(self) -> typing.Union[None, isodate.duration.Duration, timedelta]:
         """
         This grabs the timeout value for closing threads automatically
         from the ConfigManager and parses it for use internally.

--- a/core/thread.py
+++ b/core/thread.py
@@ -390,8 +390,8 @@ class Thread:
         # Grab message
         close_message = self.bot.config.get(
             "thread_auto_close_response",
-            f"This thread has been closed automatically after no response from"
-            f" you for {human_time}.",
+            f"This thread has been closed automatically due to inactivity "
+            f"after {human_time}.",
         )
         time_marker_regex = "%t"
         if len(re.findall(time_marker_regex, close_message)) == 1:

--- a/core/thread.py
+++ b/core/thread.py
@@ -343,7 +343,9 @@ class Thread:
                 if str(message_id) == str(embed.author.url).split("/")[-1]:
                     return msg
 
-    async def _fetch_timeout(self) -> typing.Union[None, isodate.duration.Duration, timedelta]:
+    async def _fetch_timeout(
+        self
+    ) -> typing.Union[None, isodate.duration.Duration, timedelta]:
         """
         This grabs the timeout value for closing threads automatically
         from the ConfigManager and parses it for use internally.
@@ -389,7 +391,7 @@ class Thread:
         close_message = self.bot.config.get(
             "thread_auto_close_response",
             f"This thread has been closed automatically after no response from"
-            f" you for {human_time}."
+            f" you for {human_time}.",
         )
         time_marker_regex = "%t"
         if len(re.findall(time_marker_regex, close_message)) == 1:
@@ -403,8 +405,7 @@ class Thread:
         if self._auto_close_task:
             self._auto_close_task.cancel()
         self._auto_close_task = self.bot.loop.call_later(
-            seconds, self._close_after, self.bot.user, False, True,
-            close_message
+            seconds, self._close_after, self.bot.user, False, True, close_message
         )
 
     async def edit_message(self, message_id: int, message: str) -> None:


### PR DESCRIPTION
… Both these can be used to configure modmail to auto close a thread after some time has passed.

`thread_auto_close_response` has a `%t` variable that can be used to insert human friendly time into the closing message.

This does not auto close threads that already exist and will have to be manually closed. But once the variable is configured, it will take it from there for every new thread.

**Take a look at this P.R with two sets of eyes as this is my first attempt at calling methods that I did not write.**

Resolves #161 