### PR TITLE
Closes #344

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1012,6 +1012,8 @@ class Modmail(commands.Cog):
 
         mention = getattr(user, "mention", f"`{user.id}`")
 
+        moderator = ctx.author.name
+
         if str(user.id) in self.bot.blocked_whitelisted_users:
             embed = discord.Embed(
                 title="Error",
@@ -1021,7 +1023,7 @@ class Modmail(commands.Cog):
             return await ctx.send(embed=embed)
 
         if after is not None:
-            reason = after.arg
+            reason = f"{after.arg} by {moderator}"
             if reason.startswith("System Message: "):
                 raise commands.BadArgument(
                     "The reason cannot start with `System Message:`."
@@ -1029,10 +1031,10 @@ class Modmail(commands.Cog):
             if "%" in reason:
                 raise commands.BadArgument('The reason contains illegal character "%".')
             if after.dt > after.now:
-                reason = f"{reason} %{after.dt.isoformat()}%"
+                reason = f"{reason} %{after.dt.isoformat()}% by {moderator}"
 
         if not reason:
-            reason = None
+            reason = f"Blocked by {moderator}"
 
         extend = f" for `{reason}`" if reason is not None else ""
         msg = self.bot.blocked_users.get(str(user.id))
@@ -1046,7 +1048,7 @@ class Modmail(commands.Cog):
         ):
             if str(user.id) in self.bot.blocked_users:
 
-                old_reason = msg.strip().rstrip(".") or "no reason"
+                old_reason = msg.strip().rstrip(".") or f"Blocked by {moderator}"
                 embed = discord.Embed(
                     title="Success",
                     description=f"{mention} was previously blocked for "

--- a/core/thread.py
+++ b/core/thread.py
@@ -763,7 +763,7 @@ class Thread:
         elif note:
             embed.colour = discord.Color.blurple()
         else:
-            embed.set_footer(text=f"Recipient")
+            embed.set_footer(text=f"Message ID: {message.id}")
             embed.colour = self.bot.recipient_color
 
         try:


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/51797295/63567620-96769780-c52f-11e9-9931-cc49bbd9a93b.png)

Closes issue #344 by replacing the footer with the message ID of the DM sent to the modmail

