### PR TITLE
Fix the contact command if more than one arguments are passed

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -907,7 +907,6 @@ class Modmail(commands.Cog):
         self,
         ctx,
         category: Optional[discord.CategoryChannel] = None,
-        *,
         user: Union[discord.Member, discord.User],
     ):
         """


### PR DESCRIPTION
Fixes: ->
![image](https://user-images.githubusercontent.com/18086566/70136419-fabe0100-16b1-11ea-9718-eef24d10a4f2.png)
and 
![image](https://user-images.githubusercontent.com/18086566/70136456-0a3d4a00-16b2-11ea-9b5f-003276bcf39f.png)
