### PR TITLE
Add my plugin

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -195,5 +195,13 @@
         "title": "Server Stats",
         "icon_url": "https://i.gyazo.com/fadb70740e83f2448b23ffe192a1f32d.png",
         "thumbnail_url": "https://i.gyazo.com/fadb70740e83f2448b23ffe192a1f32d.png"
+    },
+    "githubstats": {
+        "repository": "mischievousdev/modmail-plugins",
+        "branch": "master",
+        "description": "Github statistics in discord",
+        "bot_version": "2.20.1",
+        "icon_url": "https://raw.githubusercontent.com/mischievousdev/modmail-plugins/master/download%20(9).jpeg",
+        "thumbnail_url": "https://raw.githubusercontent.com/mischievousdev/modmail-plugins/master/download%20(9).jpeg"
     }
 }


### PR DESCRIPTION
My plugin shows the accurate statistics of Github, commands: ghuserinfo, commitinfo, issueino, repoinfo, orginfo