### PR TITLE
Use proactor eventloop for windows

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -46,6 +46,9 @@ temp_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "temp")
 if not os.path.exists(temp_dir):
     os.mkdir(temp_dir)
 
+if sys.platform == 'win32':
+    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+
 
 class ModmailBot(commands.Bot):
     def __init__(self):


### PR DESCRIPTION
`asyncio.create_subprocess_shell` is not compatible with the default event loop for windows, this change should resolve it. 