### PR TITLE
Allow a custom config dir using cmd line variables

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -48,7 +48,7 @@ if not os.path.exists(temp_dir):
 
 
 class ModmailBot(commands.Bot):
-    def __init__(self):
+    def __init__(self, args):
         super().__init__(command_prefix=None)  # implemented in `get_prefix`
         self._session = None
         self._api = None
@@ -58,7 +58,10 @@ class ModmailBot(commands.Bot):
         self._connected = asyncio.Event()
         self.start_time = datetime.utcnow()
 
-        self.config = ConfigManager(self)
+        if len(args):
+            self.config = ConfigManager(self, args[0])
+        else: 
+            self.config = ConfigManager(self)
         self.config.populate_cache()
 
         self.threads = ThreadManager(self)
@@ -1224,7 +1227,7 @@ class ModmailBot(commands.Bot):
             self.metadata_loop.cancel()
 
 
-def main():
+def main(args):
     try:
         # noinspection PyUnresolvedReferences
         import uvloop
@@ -1234,9 +1237,9 @@ def main():
     except ImportError:
         pass
 
-    bot = ModmailBot()
+    bot = ModmailBot(args)
     bot.run()
 
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])

--- a/bot.py
+++ b/bot.py
@@ -60,7 +60,7 @@ class ModmailBot(commands.Bot):
 
         if len(args):
             self.config = ConfigManager(self, args[0])
-        else: 
+        else:
             self.config = ConfigManager(self)
         self.config.populate_cache()
 

--- a/core/config.py
+++ b/core/config.py
@@ -5,7 +5,6 @@ import re
 import typing
 from copy import deepcopy
 
-from dotenv import load_dotenv
 import isodate
 
 import discord
@@ -17,7 +16,6 @@ from core.time import UserFriendlyTimeSync
 from core.utils import strtobool
 
 logger = getLogger(__name__)
-load_dotenv()
 
 
 class ConfigManager:
@@ -135,11 +133,12 @@ class ConfigManager:
     defaults = {**public_keys, **private_keys, **protected_keys}
     all_keys = set(defaults.keys())
 
-    def __init__(self, bot):
+    def __init__(self, bot, config_file = "config.json"):
         self.bot = bot
         self._cache = {}
         self.ready_event = asyncio.Event()
         self.config_help = {}
+        self.config_file = config_file
 
     def __repr__(self):
         return repr(self._cache)
@@ -148,12 +147,12 @@ class ConfigManager:
         data = deepcopy(self.defaults)
 
         # populate from env var and .env file
-        data.update({k.lower(): v for k, v in os.environ.items() if k.lower() in self.all_keys})
+        # data.update({k.lower(): v for k, v in os.environ.items() if k.lower() in self.all_keys})
         config_json = os.path.join(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "config.json"
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), self.config_file
         )
         if os.path.exists(config_json):
-            logger.debug("Loading envs from config.json.")
+            logger.debug("Loading envs from {}".format(self.config_file))
             with open(config_json, "r", encoding="utf-8") as f:
                 # Config json should override env vars
                 try:

--- a/core/config.py
+++ b/core/config.py
@@ -134,7 +134,7 @@ class ConfigManager:
     defaults = {**public_keys, **private_keys, **protected_keys}
     all_keys = set(defaults.keys())
 
-    def __init__(self, bot, config_path = os.path.dirname(os.path.abspath(__file__))):
+    def __init__(self, bot, config_path=os.path.dirname(os.path.abspath(__file__))):
         self.bot = bot
         self._cache = {}
         self.ready_event = asyncio.Event()

--- a/core/config.py
+++ b/core/config.py
@@ -5,6 +5,7 @@ import re
 import typing
 from copy import deepcopy
 
+from dotenv import load_dotenv
 import isodate
 
 import discord
@@ -133,12 +134,13 @@ class ConfigManager:
     defaults = {**public_keys, **private_keys, **protected_keys}
     all_keys = set(defaults.keys())
 
-    def __init__(self, bot, config_file = "config.json"):
+    def __init__(self, bot, config_path = os.path.dirname(os.path.abspath(__file__))):
         self.bot = bot
         self._cache = {}
         self.ready_event = asyncio.Event()
         self.config_help = {}
-        self.config_file = config_file
+        self.config_path = config_path
+        load_dotenv(dotenv_path=os.path.join(self.config_path, ".env"))
 
     def __repr__(self):
         return repr(self._cache)
@@ -147,12 +149,10 @@ class ConfigManager:
         data = deepcopy(self.defaults)
 
         # populate from env var and .env file
-        # data.update({k.lower(): v for k, v in os.environ.items() if k.lower() in self.all_keys})
-        config_json = os.path.join(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), self.config_file
-        )
+        data.update({k.lower(): v for k, v in os.environ.items() if k.lower() in self.all_keys})
+        config_json = os.path.join(self.config_path, "config.json")
         if os.path.exists(config_json):
-            logger.debug("Loading envs from {}".format(self.config_file))
+            logger.debug("Loading envs from {}".format(config_json))
             with open(config_json, "r", encoding="utf-8") as f:
                 # Config json should override env vars
                 try:


### PR DESCRIPTION
Use-case is hosting multiple instances of the bot using a single mongo database (#2813) on a single host. Just pass a path to the config dir for each instance as an argument. Config dir supports both dotenv and config.json

As far as I can tell it works as intended.