### PR TITLE
Add publish plugin to registry

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -229,7 +229,7 @@
         "description": "Publish messages sent in announcement channels.",
         "bot_version": "3.5.0",
         "title": "Publish",
-        "icon_url": "",
-        "thumbnail_url": ""
+        "icon_url": "https://user-images.githubusercontent.com/44692189/89183666-621daf00-d5b9-11ea-9b3d-a70e3e1eb197.png",
+        "thumbnail_url": "https://user-images.githubusercontent.com/44692189/89183666-621daf00-d5b9-11ea-9b3d-a70e3e1eb197.png"
     }
 }

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -229,7 +229,7 @@
         "description": "Publish messages sent in announcement channels.",
         "bot_version": "3.5.0",
         "title": "Publish",
-        "icon_url": "https://user-images.githubusercontent.com/44692189/89183666-621daf00-d5b9-11ea-9b3d-a70e3e1eb197.png",
-        "thumbnail_url": "https://user-images.githubusercontent.com/44692189/89183666-621daf00-d5b9-11ea-9b3d-a70e3e1eb197.png"
+        "icon_url": "https://user-images.githubusercontent.com/44692189/89184422-96de3600-d5ba-11ea-98ea-d096aa385ad5.png",
+        "thumbnail_url": "https://user-images.githubusercontent.com/44692189/89184422-96de3600-d5ba-11ea-98ea-d096aa385ad5.png"
     }
 }

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -222,5 +222,14 @@
         "title": "Slow Mode",
         "icon_url": "https://cdn.discordapp.com/attachments/717029057635549274/717033838966210601/Slow_mode_-_icon.png",
         "thumbnail_url": "https://cdn.discordapp.com/attachments/717029057635549274/717029110907666482/Slow_mode_plugin_-_thumbnail.png"
+    },
+       "publish": {
+        "repository": "codeinteger6/modmail-plugins",
+        "branch": "master",
+        "description": "Publish messages sent in announcement channels.",
+        "bot_version": "3.5.0",
+        "title": "Publish",
+        "icon_url": "",
+        "thumbnail_url": ""
     }
 }


### PR DESCRIPTION
Added my announcement channel publish plugin to the registry. Discord mobile currently can't publish messages sent in announcement channels so this will be helpful.