### PR TITLE
Add a "no command description" in the help command.

### DIFF
--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -50,7 +50,7 @@ class ModmailHelpCommand(commands.HelpCommand):
             format_ += (
                 f"- {cmd.short_doc}\n"
                 if not cmd.short_doc == ""
-                else "- No description."
+                else "- No description.\n"
             )
             if not format_.strip():
                 continue

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -47,7 +47,11 @@ class ModmailHelpCommand(commands.HelpCommand):
             else:
                 format_ = f"`[{perm_level}] {prefix + cmd.qualified_name}` "
 
-            format_ += f"- {cmd.short_doc}\n" if not cmd.short_doc=="" else "- No description."
+            format_ += (
+                f"- {cmd.short_doc}\n"
+                if not cmd.short_doc == ""
+                else "- No description."
+            )
             if not format_.strip():
                 continue
             if len(format_) + len(formats[-1]) >= 1024:
@@ -67,7 +71,11 @@ class ModmailHelpCommand(commands.HelpCommand):
             embed.add_field(name="Commands", value=format_ or "No commands.")
 
             continued = " (Continued)" if embeds else ""
-            name = cog.qualified_name + " - Help" if not no_cog else "Miscellaneous Commands"
+            name = (
+                cog.qualified_name + " - Help"
+                if not no_cog
+                else "Miscellaneous Commands"
+            )
             embed.set_author(name=name + continued, icon_url=bot.user.avatar_url)
 
             embed.set_footer(
@@ -88,7 +96,11 @@ class ModmailHelpCommand(commands.HelpCommand):
         bot = self.context.bot
 
         # always come first
-        default_cogs = [bot.get_cog("Modmail"), bot.get_cog("Utility"), bot.get_cog("Plugins")]
+        default_cogs = [
+            bot.get_cog("Modmail"),
+            bot.get_cog("Utility"),
+            bot.get_cog("Plugins"),
+        ]
 
         default_cogs.extend(c for c in cogs if c not in default_cogs)
 
@@ -97,12 +109,16 @@ class ModmailHelpCommand(commands.HelpCommand):
         if no_cog_commands:
             embeds.extend(await self.format_cog_help(no_cog_commands, no_cog=True))
 
-        session = EmbedPaginatorSession(self.context, *embeds, destination=self.get_destination())
+        session = EmbedPaginatorSession(
+            self.context, *embeds, destination=self.get_destination()
+        )
         return await session.run()
 
     async def send_cog_help(self, cog):
         embeds = await self.format_cog_help(cog)
-        session = EmbedPaginatorSession(self.context, *embeds, destination=self.get_destination())
+        session = EmbedPaginatorSession(
+            self.context, *embeds, destination=self.get_destination()
+        )
         return await session.run()
 
     async def _get_help_embed(self, topic):
@@ -183,7 +199,8 @@ class ModmailHelpCommand(commands.HelpCommand):
             else:
                 if len(values) == 1:
                     embed = discord.Embed(
-                        title=f"{command} is an alias.", color=self.context.bot.main_color
+                        title=f"{command} is an alias.",
+                        color=self.context.bot.main_color,
                     )
                     embed.add_field(name=f"`{command}` points to:", value=values[0])
                 else:
@@ -214,7 +231,9 @@ class ModmailHelpCommand(commands.HelpCommand):
 
         closest = get_close_matches(command, choices)
         if closest:
-            embed.add_field(name="Perhaps you meant:", value="\n".join(f"`{x}`" for x in closest))
+            embed.add_field(
+                name="Perhaps you meant:", value="\n".join(f"`{x}`" for x in closest)
+            )
         else:
             embed.title = "Cannot find command or category"
             embed.set_footer(
@@ -307,11 +326,12 @@ class Utility(commands.Cog):
 
         if self.bot.version.is_prerelease:
             stable = next(
-                filter(lambda v: not parse_version(v.version).is_prerelease, changelog.versions)
+                filter(
+                    lambda v: not parse_version(v.version).is_prerelease,
+                    changelog.versions,
+                )
             )
-            footer = (
-                f"You are on the prerelease version • the latest version is v{stable.version}."
-            )
+            footer = f"You are on the prerelease version • the latest version is v{stable.version}."
         elif self.bot.version < parse_version(latest.version):
             footer = f"A newer version is available v{latest.version}."
         else:
@@ -366,7 +386,8 @@ class Utility(commands.Cog):
 
         with open(
             os.path.join(
-                os.path.dirname(os.path.abspath(__file__)), f"../temp/{log_file_name}.log"
+                os.path.dirname(os.path.abspath(__file__)),
+                f"../temp/{log_file_name}.log",
             ),
             "r+",
         ) as f:
@@ -421,14 +442,17 @@ class Utility(commands.Cog):
 
         with open(
             os.path.join(
-                os.path.dirname(os.path.abspath(__file__)), f"../temp/{log_file_name}.log"
+                os.path.dirname(os.path.abspath(__file__)),
+                f"../temp/{log_file_name}.log",
             ),
             "rb+",
         ) as f:
             logs = BytesIO(f.read().strip())
 
         try:
-            async with self.bot.session.post(haste_url + "/documents", data=logs) as resp:
+            async with self.bot.session.post(
+                haste_url + "/documents", data=logs
+            ) as resp:
                 data = await resp.json()
                 try:
                     key = data["key"]
@@ -459,7 +483,8 @@ class Utility(commands.Cog):
 
         with open(
             os.path.join(
-                os.path.dirname(os.path.abspath(__file__)), f"../temp/{log_file_name}.log"
+                os.path.dirname(os.path.abspath(__file__)),
+                f"../temp/{log_file_name}.log",
             ),
             "w",
         ):
@@ -522,7 +547,9 @@ class Utility(commands.Cog):
         else:
             msg += f"{activity.name}."
 
-        embed = discord.Embed(title="Activity Changed", description=msg, color=self.bot.main_color)
+        embed = discord.Embed(
+            title="Activity Changed", description=msg, color=self.bot.main_color
+        )
         return await ctx.send(embed=embed)
 
     @commands.command()
@@ -559,10 +586,14 @@ class Utility(commands.Cog):
         await self.bot.config.update()
 
         msg = f"Status set to: {status.value}."
-        embed = discord.Embed(title="Status Changed", description=msg, color=self.bot.main_color)
+        embed = discord.Embed(
+            title="Status Changed", description=msg, color=self.bot.main_color
+        )
         return await ctx.send(embed=embed)
 
-    async def set_presence(self, *, status=None, activity_type=None, activity_message=None):
+    async def set_presence(
+        self, *, status=None, activity_type=None, activity_message=None
+    ):
 
         if status is None:
             status = self.bot.config.get("status")
@@ -571,7 +602,9 @@ class Utility(commands.Cog):
             activity_type = self.bot.config.get("activity_type")
 
         url = None
-        activity_message = (activity_message or self.bot.config["activity_message"]).strip()
+        activity_message = (
+            activity_message or self.bot.config["activity_message"]
+        ).strip()
         if activity_type is not None and not activity_message:
             logger.warning(
                 'No activity message found whilst activity is provided, defaults to "Modmail".'
@@ -587,7 +620,9 @@ class Utility(commands.Cog):
             url = self.bot.config["twitch_url"]
 
         if activity_type is not None:
-            activity = discord.Activity(type=activity_type, name=activity_message, url=url)
+            activity = discord.Activity(
+                type=activity_type, name=activity_message, url=url
+            )
         else:
             activity = None
         await self.bot.change_presence(activity=activity, status=status)
@@ -649,7 +684,9 @@ class Utility(commands.Cog):
 
         if mention is None:
             embed = discord.Embed(
-                title="Current mention:", color=self.bot.main_color, description=str(current)
+                title="Current mention:",
+                color=self.bot.main_color,
+                description=str(current),
             )
         else:
             embed = discord.Embed(
@@ -744,7 +781,9 @@ class Utility(commands.Cog):
                 embed = exc.embed
         else:
             embed = discord.Embed(
-                title="Error", color=self.bot.error_color, description=f"{key} is an invalid key."
+                title="Error",
+                color=self.bot.error_color,
+                description=f"{key} is an invalid key.",
             )
             valid_keys = [f"`{k}`" for k in sorted(keys)]
             embed.add_field(name="Valid keys", value=", ".join(valid_keys))
@@ -766,7 +805,9 @@ class Utility(commands.Cog):
             )
         else:
             embed = discord.Embed(
-                title="Error", color=self.bot.error_color, description=f"{key} is an invalid key."
+                title="Error",
+                color=self.bot.error_color,
+                description=f"{key} is an invalid key.",
             )
             valid_keys = [f"`{k}`" for k in sorted(keys)]
             embed.add_field(name="Valid keys", value=", ".join(valid_keys))
@@ -787,7 +828,9 @@ class Utility(commands.Cog):
             if key in keys:
                 desc = f"`{key}` is set to `{self.bot.config[key]}`"
                 embed = discord.Embed(color=self.bot.main_color, description=desc)
-                embed.set_author(name="Config variable", icon_url=self.bot.user.avatar_url)
+                embed.set_author(
+                    name="Config variable", icon_url=self.bot.user.avatar_url
+                )
 
             else:
                 embed = discord.Embed(
@@ -804,7 +847,9 @@ class Utility(commands.Cog):
                 color=self.bot.main_color,
                 description="Here is a list of currently set configuration variable(s).",
             )
-            embed.set_author(name="Current config(s):", icon_url=self.bot.user.avatar_url)
+            embed.set_author(
+                name="Current config(s):", icon_url=self.bot.user.avatar_url
+            )
             config = self.bot.config.filter_default(self.bot.config)
 
             for name, value in config.items():
@@ -832,7 +877,8 @@ class Utility(commands.Cog):
             )
             if closest:
                 embed.add_field(
-                    name=f"Perhaps you meant:", value="\n".join(f"`{x}`" for x in closest)
+                    name=f"Perhaps you meant:",
+                    value="\n".join(f"`{x}`" for x in closest),
                 )
             return await ctx.send(embed=embed)
 
@@ -855,10 +901,13 @@ class Utility(commands.Cog):
             if current_key == key:
                 index = i
             embed = discord.Embed(
-                title=f"Configuration description on {current_key}:", color=self.bot.main_color
+                title=f"Configuration description on {current_key}:",
+                color=self.bot.main_color,
             )
             embed.add_field(name="Default:", value=fmt(info["default"]), inline=False)
-            embed.add_field(name="Information:", value=fmt(info["description"]), inline=False)
+            embed.add_field(
+                name="Information:", value=fmt(info["description"]), inline=False
+            )
             if info["examples"]:
                 example_text = ""
                 for example in info["examples"]:
@@ -907,7 +956,9 @@ class Utility(commands.Cog):
         if name is not None:
             val = self.bot.aliases.get(name)
             if val is None:
-                embed = utils.create_not_found_embed(name, self.bot.aliases.keys(), "Alias")
+                embed = utils.create_not_found_embed(
+                    name, self.bot.aliases.keys(), "Alias"
+                )
                 return await ctx.send(embed=embed)
 
             values = utils.parse_alias(val)
@@ -919,14 +970,18 @@ class Utility(commands.Cog):
                     description=f"Alias `{name}` is invalid, this alias will now be deleted."
                     "This alias will now be deleted.",
                 )
-                embed.add_field(name=f"{name}` used to be:", value=utils.truncate(val, 1024))
+                embed.add_field(
+                    name=f"{name}` used to be:", value=utils.truncate(val, 1024)
+                )
                 self.bot.aliases.pop(name)
                 await self.bot.config.update()
                 return await ctx.send(embed=embed)
 
             if len(values) == 1:
                 embed = discord.Embed(
-                    title=f'Alias - "{name}":', description=values[0], color=self.bot.main_color
+                    title=f'Alias - "{name}":',
+                    description=values[0],
+                    color=self.bot.main_color,
                 )
                 return await ctx.send(embed=embed)
 
@@ -944,9 +999,12 @@ class Utility(commands.Cog):
 
         if not self.bot.aliases:
             embed = discord.Embed(
-                color=self.bot.error_color, description="You dont have any aliases at the moment."
+                color=self.bot.error_color,
+                description="You dont have any aliases at the moment.",
             )
-            embed.set_footer(text=f'Do "{self.bot.prefix}help alias" for more commands.')
+            embed.set_footer(
+                text=f'Do "{self.bot.prefix}help alias" for more commands.'
+            )
             embed.set_author(name="Aliases", icon_url=ctx.guild.icon_url)
             return await ctx.send(embed=embed)
 
@@ -974,7 +1032,9 @@ class Utility(commands.Cog):
 
         val = utils.truncate(utils.escape_code_block(val), 2048 - 7)
         embed = discord.Embed(
-            title=f'Raw alias - "{name}":', description=f"```\n{val}```", color=self.bot.main_color
+            title=f'Raw alias - "{name}":',
+            description=f"```\n{val}```",
+            color=self.bot.main_color,
         )
 
         return await ctx.send(embed=embed)
@@ -992,7 +1052,9 @@ class Utility(commands.Cog):
 
         if len(values) > 25:
             embed = discord.Embed(
-                title="Error", description="Too many steps, max=25.", color=self.bot.error_color
+                title="Error",
+                description="Too many steps, max=25.",
+                color=self.bot.error_color,
             )
             return embed
 
@@ -1003,7 +1065,9 @@ class Utility(commands.Cog):
         embed = discord.Embed(title=f"{action} alias", color=self.bot.main_color)
 
         if not multiple_alias:
-            embed.add_field(name=f"`{name}` points to:", value=utils.truncate(values[0], 1024))
+            embed.add_field(
+                name=f"`{name}` points to:", value=utils.truncate(values[0], 1024)
+            )
         else:
             embed.description = f"`{name}` now points to the following steps:"
 
@@ -1176,7 +1240,9 @@ class Utility(commands.Cog):
 
     @permissions.command(name="override")
     @checks.has_permissions(PermissionLevel.OWNER)
-    async def permissions_override(self, ctx, command_name: str.lower, *, level_name: str):
+    async def permissions_override(
+        self, ctx, command_name: str.lower, *, level_name: str
+    ):
         """
         Change a permission level for a specific command.
 
@@ -1215,7 +1281,9 @@ class Utility(commands.Cog):
                 command.qualified_name,
                 level.name,
             )
-            self.bot.config["override_command_level"][command.qualified_name] = level.name
+            self.bot.config["override_command_level"][
+                command.qualified_name
+            ] = level.name
 
             await self.bot.config.update()
             embed = discord.Embed(
@@ -1287,7 +1355,9 @@ class Utility(commands.Cog):
                     key = self.bot.modmail_guild.get_member(value)
                 if key is not None:
                     logger.info("Granting %s access to Modmail category.", key.name)
-                    await self.bot.main_category.set_permissions(key, read_messages=True)
+                    await self.bot.main_category.set_permissions(
+                        key, read_messages=True
+                    )
 
         embed = discord.Embed(
             title="Success",
@@ -1384,13 +1454,21 @@ class Utility(commands.Cog):
                         self.bot.modmail_guild.default_role, read_messages=False
                     )
                 elif isinstance(user_or_role, discord.Role):
-                    logger.info("Denying %s access to Modmail category.", user_or_role.name)
-                    await self.bot.main_category.set_permissions(user_or_role, overwrite=None)
+                    logger.info(
+                        "Denying %s access to Modmail category.", user_or_role.name
+                    )
+                    await self.bot.main_category.set_permissions(
+                        user_or_role, overwrite=None
+                    )
                 else:
                     member = self.bot.modmail_guild.get_member(value)
                     if member is not None and member != self.bot.modmail_guild.me:
-                        logger.info("Denying %s access to Modmail category.", member.name)
-                        await self.bot.main_category.set_permissions(member, overwrite=None)
+                        logger.info(
+                            "Denying %s access to Modmail category.", member.name
+                        )
+                        await self.bot.main_category.set_permissions(
+                            member, overwrite=None
+                        )
 
         embed = discord.Embed(
             title="Success",
@@ -1440,7 +1518,11 @@ class Utility(commands.Cog):
     @permissions.command(name="get", usage="[@user] or [command/level/override] [name]")
     @checks.has_permissions(PermissionLevel.OWNER)
     async def permissions_get(
-        self, ctx, user_or_role: Union[discord.Role, utils.User, str], *, name: str = None
+        self,
+        ctx,
+        user_or_role: Union[discord.Role, utils.User, str],
+        *,
+        name: str = None,
     ):
         """
         View the currently-set permissions.
@@ -1490,7 +1572,9 @@ class Utility(commands.Cog):
                 if value in permissions:
                     levels.append(level.name)
 
-            mention = getattr(user_or_role, "name", getattr(user_or_role, "id", user_or_role))
+            mention = getattr(
+                user_or_role, "name", getattr(user_or_role, "id", user_or_role)
+            )
             desc_cmd = (
                 ", ".join(map(lambda x: f"`{x}`", cmds))
                 if cmds
@@ -1540,10 +1624,14 @@ class Utility(commands.Cog):
                             )
                         )
                     else:
-                        for items in zip_longest(*(iter(sorted(overrides.items())),) * 15):
+                        for items in zip_longest(
+                            *(iter(sorted(overrides.items())),) * 15
+                        ):
                             description = "\n".join(
                                 ": ".join((f"`{name}`", level))
-                                for name, level in takewhile(lambda x: x is not None, items)
+                                for name, level in takewhile(
+                                    lambda x: x is not None, items
+                                )
                             )
                             embed = discord.Embed(
                                 color=self.bot.main_color, description=description
@@ -1599,7 +1687,9 @@ class Utility(commands.Cog):
                     return await ctx.send(embed=embed)
 
                 if user_or_role == "command":
-                    embeds.append(self._get_perm(ctx, command.qualified_name, "command"))
+                    embeds.append(
+                        self._get_perm(ctx, command.qualified_name, "command")
+                    )
                 else:
                     embeds.append(self._get_perm(ctx, level.name, "level"))
             else:
@@ -1608,7 +1698,9 @@ class Utility(commands.Cog):
                     for command in self.bot.walk_commands():
                         if command not in done:
                             done.add(command)
-                            embeds.append(self._get_perm(ctx, command.qualified_name, "command"))
+                            embeds.append(
+                                self._get_perm(ctx, command.qualified_name, "command")
+                            )
                 else:
                     for perm_level in PermissionLevel:
                         embeds.append(self._get_perm(ctx, perm_level.name, "level"))
@@ -1650,7 +1742,9 @@ class Utility(commands.Cog):
         embed.title = "Success"
 
         if not hasattr(target, "mention"):
-            target = self.bot.get_user(target.id) or self.bot.modmail_guild.get_role(target.id)
+            target = self.bot.get_user(target.id) or self.bot.modmail_guild.get_role(
+                target.id
+            )
 
         embed.description = (
             f"{'Un-w' if removed else 'W'}hitelisted {target.mention} to view logs."
@@ -1678,8 +1772,12 @@ class Utility(commands.Cog):
         embed = discord.Embed(color=self.bot.main_color)
         embed.title = "Oauth Whitelist"
 
-        embed.add_field(name="Users", value=" ".join(u.mention for u in users) or "None")
-        embed.add_field(name="Roles", value=" ".join(r.mention for r in roles) or "None")
+        embed.add_field(
+            name="Users", value=" ".join(u.mention for u in users) or "None"
+        )
+        embed.add_field(
+            name="Roles", value=" ".join(r.mention for r in roles) or "None"
+        )
 
         await ctx.send(embed=embed)
 

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -47,7 +47,7 @@ class ModmailHelpCommand(commands.HelpCommand):
             else:
                 format_ = f"`[{perm_level}] {prefix + cmd.qualified_name}` "
 
-            format_ += f"- {cmd.short_doc}\n"
+            format_ += f"- {cmd.short_doc}\n" if not cmd.short_doc=="" else "- No description."
             if not format_.strip():
                 continue
             if len(format_) + len(formats[-1]) >= 1024:


### PR DESCRIPTION
This should work, for example, when someone tries to see the Moderation plugin. Commands in that plugin have no description, so it will show "No description." instead of nothing.