### PR TITLE
⚡ Adds autopublish plugin

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -240,5 +240,14 @@
         "title": "Publish",
         "icon_url": "https://user-images.githubusercontent.com/44692189/89184422-96de3600-d5ba-11ea-98ea-d096aa385ad5.png",
         "thumbnail_url": "https://user-images.githubusercontent.com/44692189/89184422-96de3600-d5ba-11ea-98ea-d096aa385ad5.png"
+    },
+    "autopublish": {
+        "repository": "officialakhil/modmail-plugins",
+        "branch": "master",
+        "description": "Auto Publish messages sent in announcement channels.",
+        "bot_version": "3.5.0",
+        "title": "AutoPublish",
+        "icon_url": "https://media.discordapp.net/attachments/511385199612002304/756412300512067664/AKHIL.png?width=431&height=431",
+        "thumbnail_url": "https://media.discordapp.net/attachments/511385199612002304/756412300512067664/AKHIL.png?width=431&height=431"
     }
 }


### PR DESCRIPTION
## AutoPublish Plugin

AutoPublish Cog has the following commands:

- `[p]track <channel>` : Used to add an Announcement channel to be tracked. This means all the messages that gets sent in that particular announcements channel get auto published.
- `[p]remove <channel>` : Remove a channel from tracking.
- `[p]listtracks` : List all the channels that are being tracked in the server. 
- `[p]publish <msgid>` : This command is from [Codeinteger6's publish plugin](https://github.com/codeinteger6/modmail-plugins/tree/master/publish). Used to publish a particular message manually. 

Add the cog using the command `[p]plugins add officialakhil/modmail-plugins/autopublish`

**Note:** You might want to uninstall the `publish` plugin to install this due to clash with the command name of `publish`. 