### PR TITLE
Add MODMAIL_GUILD_ID variable in example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 TOKEN=MyBotToken
 LOG_URL=https://logviewername.herokuapp.com/
 GUILD_ID=1234567890
+MODMAIL_GUILD_ID=1234567890
 OWNERS=Owner1ID,Owner2ID,Owner3ID
 CONNECTION_URI=mongodb+srv://mongodburi


### PR DESCRIPTION
This variable was missing from the env example file for quite some time now.