### PR TITLE
Fix link to CONTRIBUTING

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Plugins requests and support is available in our [Modmail Plugins Server](https:
 
 ## Contributing
 
-Contributions to Modmail are always welcome, whether it be improvements to the documentation or new functionality, please feel free to make the change. Check out our [contributing guidelines](https://github.com/kyb3r/modmail/blob/master/CONTRIBUTING.md) before you get started.
+Contributions to Modmail are always welcome, whether it be improvements to the documentation or new functionality, please feel free to make the change. Check out our [contributing guidelines](https://github.com/kyb3r/modmail/blob/master/.github/CONTRIBUTING.md) before you get started.
 
 If you like this project and would like to show your appreciation, support us on **[Patreon](https://www.patreon.com/kyber)**!
 


### PR DESCRIPTION
Fixes the link to [CONTRIBUTING](https://github.com/kyb3r/modmail/blob/master/.github/CONTRIBUTING.md) in [README](https://github.com/kyb3r/modmail/blob/master/README.md) broken by 714f5316d8e647af1c2862b635eedd000eeccf80