### PR TITLE
fix typo

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -81,7 +81,7 @@ The Modmail team does not track any data by users.
 
 ### Opting out
 
-There is no way for users or moderators to opt out frmo this data collection.
+There is no way for users or moderators to opt out from this data collection.
 
 ### Data deletion
 


### PR DESCRIPTION
In PRIVACY.md file, at L84 there is a typo. It should be `from` instead of `frmo` therefore this PR fixes that. 