### PR TITLE
Fix couple of errors raised when the recipient is not cached.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1153,7 +1153,7 @@ class ModmailBot(commands.Bot):
 
     async def handle_reaction_events(self, payload):
         user = self.get_user(payload.user_id)
-        if user.bot:
+        if user is None or user.bot:
             return
 
         channel = self.get_channel(payload.channel_id)

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -680,7 +680,7 @@ class Modmail(commands.Cog):
             thread = ctx.thread
             if not thread:
                 raise commands.MissingRequiredArgument(SimpleNamespace(name="member"))
-            user = thread.recipient
+            user = thread.recipient or await self.bot.fetch_user(thread.id)
 
         default_avatar = "https://cdn.discordapp.com/embed/avatars/0.png"
         icon_url = getattr(user, "avatar_url", default_avatar)


### PR DESCRIPTION
-  Fix error raised when recipient is not cached and reacts to reactions in DM channel.
- Resolves #2935 . 