### PR TITLE
Add ability to disable mention on thread creation.

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -341,7 +341,11 @@ class Modmail(commands.Cog):
 
         if self.bot.config["thread_move_notify_mods"]:
             mention = self.bot.config["mention"]
-            await thread.channel.send(f"{mention}, thread has been moved.")
+            if mention is not None:
+                msg = f"{mention}, thread has been moved."
+            else:
+                msg = "Thread has been moved."
+            await thread.channel.send(msg)
 
         sent_emoji, _ = await self.bot.retrieve_emoji()
         await self.bot.add_reaction(ctx.message, sent_emoji)

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -690,9 +690,9 @@ class Utility(commands.Cog):
         elif (
             len(mention) == 1
             and isinstance(mention[0], str)
-            and mention[0] in ["disable", "reset"]
+            and mention[0].lower() in ["disable", "reset"]
         ):
-            option = mention[0]
+            option = mention[0].lower()
             if option == "disable":
                 embed = discord.Embed(
                     description=f"Disabled mention on thread creation.", color=self.bot.main_color,
@@ -700,7 +700,7 @@ class Utility(commands.Cog):
                 self.bot.config["mention"] = None
             else:
                 embed = discord.Embed(
-                    description="`mention` had been reset to default.", color=self.bot.main_color,
+                    description="`mention` is reset to default.", color=self.bot.main_color,
                 )
                 self.bot.config.remove("mention")
             await self.bot.config.update()

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -695,8 +695,7 @@ class Utility(commands.Cog):
             option = mention[0]
             if option == "disable":
                 embed = discord.Embed(
-                    description=f"Disabled mention on thread creation.",
-                    color=self.bot.main_color,
+                    description=f"Disabled mention on thread creation.", color=self.bot.main_color,
                 )
                 self.bot.config["mention"] = None
             else:

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -674,20 +674,41 @@ class Utility(commands.Cog):
 
     @commands.command()
     @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
-    async def mention(self, ctx, *mention: Union[discord.Role, discord.Member]):
+    async def mention(self, ctx, *mention: Union[discord.Role, discord.Member, str]):
         """
         Change what the bot mentions at the start of each thread.
 
         Type only `{prefix}mention` to retrieve your current "mention" message.
+        `{prefix}mention disable` to disable mention.
+        `{prefix}mention reset` to reset it to default value.
         """
-        # TODO: ability to disable mention.
         current = self.bot.config["mention"]
-
         if not mention:
             embed = discord.Embed(
                 title="Current mention:", color=self.bot.main_color, description=str(current)
             )
+        elif (
+            len(mention) == 1
+            and isinstance(mention[0], str)
+            and mention[0] in ["disable", "reset"]
+        ):
+            option = mention[0]
+            if option == "disable":
+                embed = discord.Embed(
+                    description=f"Disabled mention on thread creation.",
+                    color=self.bot.main_color,
+                )
+                self.bot.config["mention"] = None
+            else:
+                embed = discord.Embed(
+                    description="`mention` had been reset to default.", color=self.bot.main_color,
+                )
+                self.bot.config.remove("mention")
+            await self.bot.config.update()
         else:
+            for m in mention:
+                if not isinstance(m, (discord.Role, discord.Member)):
+                    raise commands.BadArgument(f'Role or Member "{m}" not found.')
             mention = " ".join(i.mention for i in mention)
             embed = discord.Embed(
                 title="Changed mention!",


### PR DESCRIPTION
Ability to disable mention on thread creation:
- `?mention disable` to disable mention. The bot sets the mention value to `None`.
- `?mention reset` to reset mention to default value, currently `@here`.