### PR TITLE
Add msglink command to get DM message URLs.

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -604,11 +604,13 @@ class Modmail(commands.Cog):
     @commands.command()
     @checks.has_permissions(PermissionLevel.SUPPORTER)
     @checks.thread_only()
-    async def loglink(self, ctx, message_id: int):
+    async def msglink(self, ctx, message_id: int):
         """Retrieves the link to a message in the current thread."""
         message = await ctx.thread.recipient.fetch_message(message_id)
         if not message:
-            embed = discord.Embed(color=self.bot.main_color, description="Message no longer exists.")
+            embed = discord.Embed(
+                color=self.bot.main_color, description="Message no longer exists."
+            )
         else:
             embed = discord.Embed(color=self.bot.main_color, description=message.jump_url)
         await ctx.send(embed=embed)

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -606,13 +606,16 @@ class Modmail(commands.Cog):
     @checks.thread_only()
     async def msglink(self, ctx, message_id: int):
         """Retrieves the link to a message in the current thread."""
-        message = await ctx.thread.recipient.fetch_message(message_id)
-        if not message:
+        try:
+            message = await ctx.thread.recipient.fetch_message(message_id)
+        except discord.NotFound:
             embed = discord.Embed(
-                color=self.bot.main_color, description="Message no longer exists."
+                color=self.bot.error_color, description="Message not found or no longer exists."
             )
         else:
-            embed = discord.Embed(color=self.bot.main_color, description=message.jump_url)
+            embed = discord.Embed(
+                color=self.bot.main_color, description=message.jump_url
+            )
         await ctx.send(embed=embed)
 
     @commands.command()

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -604,6 +604,18 @@ class Modmail(commands.Cog):
     @commands.command()
     @checks.has_permissions(PermissionLevel.SUPPORTER)
     @checks.thread_only()
+    async def loglink(self, ctx, message_id: int):
+        """Retrieves the link to a message in the current thread."""
+        message = await ctx.thread.recipient.fetch_message(message_id)
+        if not message:
+            embed = discord.Embed(color=self.bot.main_color, description="Message no longer exists.")
+        else:
+            embed = discord.Embed(color=self.bot.main_color, description=message.jump_url)
+        await ctx.send(embed=embed)
+
+    @commands.command()
+    @checks.has_permissions(PermissionLevel.SUPPORTER)
+    @checks.thread_only()
     async def loglink(self, ctx):
         """Retrieves the link to the current thread's logs."""
         log_link = await self.bot.api.get_log_link(ctx.channel.id)

--- a/core/thread.py
+++ b/core/thread.py
@@ -300,7 +300,11 @@ class Thread:
         #     embed.add_field(name='Mention', value=user.mention)
         # embed.add_field(name='Registered', value=created + days(created))
 
-        footer = "User ID: " + str(user.id)
+        if user.dm_channel:
+            footer = f"User ID: {user.id} • DM ID: {user.dm_channel}"
+        else:
+            footer = f"User ID: {user.id}"
+
         embed.set_author(name=str(user), icon_url=user.avatar_url, url=log_url)
         # embed.set_thumbnail(url=avi)
 


### PR DESCRIPTION
Closes #2963 

As this addition was quite small and relatively easy to implement, and that the Issue I created was marked as High Priority, I figured I'd try sending in a PR directly. 

I decided that the command name of `msglink` is probably more preferable to the originally proposed `jumplink` as the term Message Link is used directly in the context menu option so may be most familiar and clear in purpose for general users.

For the genesis info embed change, I was unsure if there'd ever be a situation where the dm_channel does not exist so as a just-in-case, accounted for it. 

Cheers.