### PR TITLE
Use the ID for DM ID.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ You can find a list of third-party plugins using the `?plugins registry`  comman
 
 To develop your own, check out the [plugins documentation](https://github.com/kyb3r/modmail/wiki/Plugins).
 
-Plugins requests and support is available in our [Modmail Plugins Server](https://discord.gg/4JE4XSW).
+Plugins requests and support are available in our [Modmail Support Server](https://discord.gg/j5e9p8w).
 
 ## Contributing
 

--- a/core/thread.py
+++ b/core/thread.py
@@ -301,7 +301,7 @@ class Thread:
         # embed.add_field(name='Registered', value=created + days(created))
 
         if user.dm_channel:
-            footer = f"User ID: {user.id} • DM ID: {user.dm_channel}"
+            footer = f"User ID: {user.id} • DM ID: {user.dm_channel.id}"
         else:
             footer = f"User ID: {user.id}"
 


### PR DESCRIPTION
Originally used the channel instance by mistake, causing the `__str__` to be used instead of the intended ID.