### PR TITLE
Use the ID attribute of DM Channel.

### DIFF
--- a/core/thread.py
+++ b/core/thread.py
@@ -301,7 +301,7 @@ class Thread:
         # embed.add_field(name='Registered', value=created + days(created))
 
         if user.dm_channel:
-            footer = f"User ID: {user.id} • DM ID: {user.dm_channel}"
+            footer = f"User ID: {user.id} • DM ID: {user.dm_channel.id}"
         else:
             footer = f"User ID: {user.id}"
 


### PR DESCRIPTION
Originally used the channel instance by mistake, causing the `__str__` to be used instead of the intended ID.