### PR TITLE
Bug fixes related to 'react_to_contact' and 'confirm_thread_creation'.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1188,6 +1188,14 @@ class ModmailBot(commands.Bot):
                     # the reacted message is the corresponding thread creation embed
                     # closing thread
                     return await thread.close(closer=user)
+            if (
+                message.author == self.user
+                and message.embeds
+                and self.config.get("confirm_thread_creation")
+                and message.embeds[0].title == self.config["confirm_thread_creation_title"]
+                and message.embeds[0].description == self.config["confirm_thread_response"]
+            ):
+                return
             if not thread.recipient.dm_channel:
                 await thread.recipient.create_dm()
             try:

--- a/bot.py
+++ b/bot.py
@@ -1238,14 +1238,32 @@ class ModmailBot(commands.Bot):
                     if not member.bot:
                         message = await channel.fetch_message(payload.message_id)
                         await message.remove_reaction(payload.emoji, member)
+                        await message.add_reaction(emoji_fmt)  # bot adds as well
+
+                        if self.config["dm_disabled"] in (
+                            DMDisabled.NEW_THREADS,
+                            DMDisabled.ALL_THREADS,
+                        ):
+                            embed = discord.Embed(
+                                title=self.config["disabled_new_thread_title"],
+                                color=self.error_color,
+                                description=self.config["disabled_new_thread_response"],
+                            )
+                            embed.set_footer(
+                                text=self.config["disabled_new_thread_footer"],
+                                icon_url=self.guild.icon_url,
+                            )
+                            logger.info(
+                                "A new thread using react to contact was blocked from %s due to disabled Modmail.",
+                                message.author,
+                            )
+                            return await member.send(embed=embed)
 
                         ctx = await self.get_context(message)
                         ctx.author = member
                         await ctx.invoke(
                             self.get_command("contact"), user=member, manual_trigger=False
                         )
-
-                        await message.add_reaction(emoji_fmt)  # bot adds as well
 
     async def on_raw_reaction_remove(self, payload):
         if self.config["transfer_reactions"]:

--- a/bot.py
+++ b/bot.py
@@ -1263,7 +1263,7 @@ class ModmailBot(commands.Bot):
                             )
                             logger.info(
                                 "A new thread using react to contact was blocked from %s due to disabled Modmail.",
-                                message.author,
+                                member,
                             )
                             return await member.send(embed=embed)
 

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1027,7 +1027,12 @@ class Modmail(commands.Cog):
             await ctx.channel.send(embed=embed, delete_after=3)
 
         else:
-            thread = await self.bot.threads.create(user, creator=ctx.author, category=category)
+            thread = await self.bot.threads.create(
+                recipient=user,
+                creator=ctx.author,
+                category=category,
+                manual_trigger=manual_trigger,
+            )
             if self.bot.config["dm_disabled"] in (DMDisabled.NEW_THREADS, DMDisabled.ALL_THREADS):
                 logger.info("Contacting user %s when Modmail DM is disabled.", user)
 


### PR DESCRIPTION
About this PR:
-Sends confirm thread creation message when a user opens a thread using react to contact. -Resolves #2930 
-Blocks from creating a new thread from react to contact when Modmail DM is disabled (`new` or `all`). - Resolves #2969 

Internal:
-No attempt to find for linked message when the recipient reacts to reactions on confirm thread creation message.