### PR TITLE
Update `mention` command.

### DIFF
--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -673,41 +673,62 @@ class Utility(commands.Cog):
 
     @commands.command()
     @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
-    async def mention(self, ctx, *mention: Union[discord.Role, discord.Member, str]):
+    async def mention(self, ctx, *user_or_role: Union[discord.Role, discord.Member, str]):
         """
         Change what the bot mentions at the start of each thread.
 
-        Type only `{prefix}mention` to retrieve your current "mention" message.
-        `{prefix}mention disable` to disable mention.
-        `{prefix}mention reset` to reset it to default value.
+        `user_or_role` may be a user ID, mention, name, role ID, mention, or name.
+        You can also set it to mention multiple users or roles, just separate the arguments with space.
+
+        Examples:
+        - `{prefix}mention @user`
+        - `{prefix}mention @user @role`
+        - `{prefix}mention 984301093849028 388218663326449`
+        - `{prefix}mention everyone`
+
+        Do not ping `@everyone` to set mention to everyone, use "everyone" or "all" instead.
+
+        Notes:
+        - Type only `{prefix}mention` to retrieve your current "mention" message.
+        - `{prefix}mention disable` to disable mention.
+        - `{prefix}mention reset` to reset it to default value, which is "@here".
         """
         current = self.bot.config["mention"]
-        if not mention:
+        if not user_or_role:
             embed = discord.Embed(
                 title="Current mention:", color=self.bot.main_color, description=str(current)
             )
         elif (
-            len(mention) == 1
-            and isinstance(mention[0], str)
-            and mention[0].lower() in ["disable", "reset"]
+            len(user_or_role) == 1
+            and isinstance(user_or_role[0], str)
+            and user_or_role[0].lower() in ("disable", "reset", "all", "everyone")
         ):
-            option = mention[0].lower()
+            option = user_or_role[0].lower()
             if option == "disable":
                 embed = discord.Embed(
                     description=f"Disabled mention on thread creation.", color=self.bot.main_color,
                 )
                 self.bot.config["mention"] = None
-            else:
+            elif option == "reset":
                 embed = discord.Embed(
                     description="`mention` is reset to default.", color=self.bot.main_color,
                 )
                 self.bot.config.remove("mention")
+            else:
+                embed = discord.Embed(
+                    title="Changed mention!",
+                    description=f'On thread creation the bot now says "@everyone".',
+                    color=self.bot.main_color,
+                )
+                self.bot.config["mention"] = "@everyone"
             await self.bot.config.update()
         else:
-            for m in mention:
+            for m in user_or_role:
                 if not isinstance(m, (discord.Role, discord.Member)):
                     raise commands.BadArgument(f'Role or Member "{m}" not found.')
-            mention = " ".join(i.mention for i in mention)
+            mention = " ".join(
+                i.mention if i is not ctx.guild.default_role else str(i) for i in user_or_role
+            )
             embed = discord.Embed(
                 title="Changed mention!",
                 description=f'On thread creation the bot now says "{mention}".',

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -701,7 +701,7 @@ class Utility(commands.Cog):
         elif (
             len(user_or_role) == 1
             and isinstance(user_or_role[0], str)
-            and user_or_role[0].lower() in ("disable", "reset", "all", "everyone")
+            and user_or_role[0].lower() in ("disable", "reset")
         ):
             option = user_or_role[0].lower()
             if option == "disable":
@@ -709,26 +709,24 @@ class Utility(commands.Cog):
                     description=f"Disabled mention on thread creation.", color=self.bot.main_color,
                 )
                 self.bot.config["mention"] = None
-            elif option == "reset":
+            else:
                 embed = discord.Embed(
                     description="`mention` is reset to default.", color=self.bot.main_color,
                 )
                 self.bot.config.remove("mention")
-            else:
-                embed = discord.Embed(
-                    title="Changed mention!",
-                    description=f'On thread creation the bot now says "@everyone".',
-                    color=self.bot.main_color,
-                )
-                self.bot.config["mention"] = "@everyone"
             await self.bot.config.update()
         else:
+            mention = []
+            everyone = ("all", "everyone")
             for m in user_or_role:
-                if not isinstance(m, (discord.Role, discord.Member)):
+                if not isinstance(m, (discord.Role, discord.Member)) and m not in everyone:
                     raise commands.BadArgument(f'Role or Member "{m}" not found.')
-            mention = " ".join(
-                i.mention if i is not ctx.guild.default_role else str(i) for i in user_or_role
-            )
+                elif m == ctx.guild.default_role or m in everyone:
+                    mention.append("@everyone")
+                    continue
+                mention.append(m.mention)
+
+            mention = " ".join(mention)
             embed = discord.Embed(
                 title="Changed mention!",
                 description=f'On thread creation the bot now says "{mention}".',

--- a/core/config_help.json
+++ b/core/config_help.json
@@ -52,7 +52,8 @@
       "`{prefix}mention Yo~ Here's a new thread for ya!`"
     ],
     "notes": [
-      "Unfortunately, it's not currently possible to disable mention. You do not have to include a mention."
+      "To disable mention, use command `{prefix}mention disable`.",
+      "See also: `{prefix}help mention`."
     ]
   },
   "main_color": {


### PR DESCRIPTION
-Updated `mention` command and its description, added more details about its usage.
Also an option to set mention to `@everyone` just by providing "everyone" or "all" (similar with `?perms add` command).