### PR TITLE
Change Max Channel per Category to 49

### DIFF
--- a/core/thread.py
+++ b/core/thread.py
@@ -1205,7 +1205,7 @@ class ThreadManager:
 
         # Schedule thread setup for later
         cat = self.bot.main_category
-        if category is None and len(cat.channels) == 50:
+        if category is None and len(cat.channels) == 49:
             fallback_id = self.bot.config["fallback_category_id"]
             if fallback_id:
                 fallback = discord.utils.get(cat.guild.categories, id=int(fallback_id))

--- a/core/thread.py
+++ b/core/thread.py
@@ -1209,7 +1209,7 @@ class ThreadManager:
             fallback_id = self.bot.config["fallback_category_id"]
             if fallback_id:
                 fallback = discord.utils.get(cat.guild.categories, id=int(fallback_id))
-                if fallback and len(fallback.channels) != 50:
+                if fallback and len(fallback.channels) < 49:
                     category = fallback
 
             if not category:

--- a/core/thread.py
+++ b/core/thread.py
@@ -1205,7 +1205,7 @@ class ThreadManager:
 
         # Schedule thread setup for later
         cat = self.bot.main_category
-        if category is None and len(cat.channels) == 49:
+        if category is None and len(cat.channels) >= 49:
             fallback_id = self.bot.config["fallback_category_id"]
             if fallback_id:
                 fallback = discord.utils.get(cat.guild.categories, id=int(fallback_id))


### PR DESCRIPTION
Addresses https://github.com/kyb3r/modmail/issues/3002
Will add a 1 channel buffer to the check to account for Discord API bugs preventing the category from actually reaching 50 channels.