### PR TITLE
Add docker-compose configuration for self hosting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.7"
+services:
+  bot:
+    image: kyb3rr/modmail
+    env_file:
+      - .env
+    depends_on:
+      - mongo
+  logviewer:
+    image: kyb3rr/logviewer
+    depends_on:
+      - mongo
+    environment:
+      - MONGO_URI=mongodb://mongo
+    ports:
+      - 8000:8000
+  mongo:
+    image: mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,8 @@ services:
       - 8000:8000
   mongo:
     image: mongo
+    volumes:
+      - mongodb:/data/db
+
+volumes:
+  mongodb:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,20 +2,25 @@ version: "3.7"
 services:
   bot:
     image: kyb3rr/modmail
+    restart: always
     env_file:
       - .env
+    environment:
+      - CONNECTION_URI=mongodb://mongo
     depends_on:
       - mongo
   logviewer:
     image: kyb3rr/logviewer
+    restart: always
     depends_on:
       - mongo
     environment:
       - MONGO_URI=mongodb://mongo
     ports:
-      - 8000:8000
+      - 80:8000
   mongo:
     image: mongo
+    restart: always
     volumes:
       - mongodb:/data/db
 


### PR DESCRIPTION
Adds a docker-compose configuration file for running both the bot and logviewer with a shared mongo database in a single container stack.

Exposes port 8000 and ensure the mongo database can not be accessed remotely.