### PR TITLE
Fix bug on command `?config remove`

### DIFF
--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -819,7 +819,9 @@ class Utility(commands.Cog):
                 embed = exc.embed
         else:
             embed = discord.Embed(
-                title="Error", color=self.bot.error_color, description=f"{key} is an invalid key."
+                title="Error",
+                color=self.bot.error_color,
+                description=f"`{key}` is an invalid key.",
             )
             valid_keys = [f"`{k}`" for k in sorted(keys)]
             embed.add_field(name="Valid keys", value=truncate(", ".join(valid_keys), 1024))
@@ -841,10 +843,12 @@ class Utility(commands.Cog):
             )
         else:
             embed = discord.Embed(
-                title="Error", color=self.bot.error_color, description=f"{key} is an invalid key."
+                title="Error",
+                color=self.bot.error_color,
+                description=f"`{key}` is an invalid key.",
             )
             valid_keys = [f"`{k}`" for k in sorted(keys)]
-            embed.add_field(name="Valid keys", value=", ".join(valid_keys))
+            embed.add_field(name="Valid keys", value=truncate(", ".join(valid_keys), 1024))
 
         return await ctx.send(embed=embed)
 


### PR DESCRIPTION
Fix bug bot doesn't respond on command `?config remove <key>` if invalid `key` is provided due to embed field's value exceeds the limit.

**Steps to reproduce:**
- Run command `?config remove <invalid key here>`.

**Error:**
```py
discord.errors.HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In embed.fields.0.value: Must be 1024 or fewer in length.
```