### PR TITLE
Support for linking plain messages.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1286,7 +1286,7 @@ class ModmailBot(commands.Bot):
             if not thread:
                 return
             try:
-                _, linked_message = await thread.find_linked_messages(
+                _, linked_message, _ = await thread.find_linked_messages(
                     message.id, either_direction=True
                 )
             except ValueError as e:

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -965,12 +965,12 @@ class Modmail(commands.Cog):
         thread = ctx.thread
 
         try:
-            await thread.edit_message(message_id, message)
+            await thread.edit_message(ctx.author, message_id, message)
         except ValueError:
             return await ctx.send(
                 embed=discord.Embed(
                     title="Failed",
-                    description="Cannot find a message to edit. Plain messages are not supported.",
+                    description="Cannot find a message to edit.",
                     color=self.bot.error_color,
                 )
             )

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1405,11 +1405,11 @@ class Modmail(commands.Cog):
         try:
             await thread.delete_message(message_id, note=True)
         except ValueError as e:
-            logger.warning("Failed to delete message: %s.", e)
+            logger.warning("Failed to delete message: %s", e)
             return await ctx.send(
                 embed=discord.Embed(
                     title="Failed",
-                    description="Cannot find a message to delete. Plain messages are not supported.",
+                    description="Cannot find a message to delete.",
                     color=self.bot.error_color,
                 )
             )

--- a/core/clients.py
+++ b/core/clients.py
@@ -329,6 +329,7 @@ class ApiClient:
         message_id: str = "",
         channel_id: str = "",
         type_: str = "thread_message",
+        linked_ids: list = None,
     ) -> dict:
         return NotImplemented
 
@@ -562,13 +563,18 @@ class MongoDBClient(ApiClient):
         message_id: str = "",
         channel_id: str = "",
         type_: str = "thread_message",
+        linked_ids: list = None,
     ) -> dict:
         channel_id = str(channel_id) or str(message.channel.id)
         message_id = str(message_id) or str(message.id)
 
+        # index 0 thread msg id, index 1 dm msg id
+        linked_ids = [str(msg_id) for msg_id in linked_ids] if linked_ids else []
+
         data = {
             "timestamp": str(message.created_at),
             "message_id": message_id,
+            "linked_ids": linked_ids,
             "author": {
                 "id": str(message.author.id),
                 "name": message.author.name,

--- a/core/thread.py
+++ b/core/thread.py
@@ -562,15 +562,16 @@ class Thread:
     ) -> typing.Tuple[discord.Message, typing.Optional[discord.Message], bool]:
         if message1 is not None:
             if not (
-                message1.author == self.bot.user and message1.embeds,
-                message1.embeds[0].color
+                message1.author == self.bot.user
+                and message1.embeds
+                and message1.embeds[0].color
                 and (
                     message1.embeds[0].color.value == self.bot.mod_color
                     or (
                         either_direction
                         and message1.embeds[0].color.value == self.bot.recipient_color
                     )
-                ),
+                )
             ):
                 raise ValueError("Malformed thread message.")
 

--- a/core/thread.py
+++ b/core/thread.py
@@ -585,9 +585,10 @@ class Thread:
             ):
                 raise ValueError("Malformed thread message.")
 
-            if message1.embeds[0].color.value == self.bot.main_color and message1.embeds[
-                0
-            ].author.name.startswith("Note"):
+            if message1.embeds[0].color.value == self.bot.main_color and (
+                message1.embeds[0].author.name.startswith("Note")
+                or message1.embeds[0].author.name.startswith("Persistent Note")
+            ):
                 if not note:
                     raise ValueError("Thread message not found.")
                 return message1, None, False


### PR DESCRIPTION
Regarding issue #2876 

__**About this PR:**__
- Support for linking plain messages.
- Deleting and editing plain messages both work.
- Now uses database to store and fetch the linked IDs.
- Add parameter `linked_ids` (type: list) for method `append_log` in `clients.py`. The linked IDs will be stored when the thread message is sent whether from thread or DM.
- No longer find linked messages matching from embed author url.
- Add another return value (type: str) for method `find_linked_messages` in `thread.py`, which would be the type of the thread message. Expected "thread_message", "anonymous", or "system".
- Add parameter `author` (type: [discord.Member](https://discordpy.readthedocs.io/en/latest/api.html#member)) for method `edit_message` in `thread.py`.

__**Note:**__
- Linking multiple images to a single message is still not supported.