### PR TITLE
Fix raw snippet markdown

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -191,7 +191,7 @@ class Modmail(commands.Cog):
             val = truncate(escape_code_block(val), 2048 - 7)
             embed = discord.Embed(
                 title=f'Raw snippet - "{name}":',
-                description=f"```\n{val}```",
+                description=f"```md\n{val}\n```",
                 color=self.bot.main_color,
             )
 


### PR DESCRIPTION
If a snippet ended with a \`, it would mean that there would be a row of 4 \`\`\`\` in a row, causing the snippet raw text to have a small error in markdown formatting.

This fixes that, in addition to making the code block language `markdown`.