### PR TITLE
Fix UnicodeEncodeError on Windows.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -659,7 +659,7 @@ class ModmailBot(commands.Bot):
             try:
                 name = await converter.convert(ctx, name.strip(":"))
             except commands.BadArgument as e:
-                logger.warning("%s is not a valid emoji. %s.", e)
+                logger.warning("%s is not a valid emoji. %s.", name, e)
                 raise
         return name
 

--- a/bot.py
+++ b/bot.py
@@ -122,12 +122,9 @@ class ModmailBot(commands.Bot):
 
     def startup(self):
         logger.line()
-        if os.name != "nt":
-            logger.info("┌┬┐┌─┐┌┬┐┌┬┐┌─┐┬┬")
-            logger.info("││││ │ │││││├─┤││")
-            logger.info("┴ ┴└─┘─┴┘┴ ┴┴ ┴┴┴─┘")
-        else:
-            logger.info("MODMAIL")
+        logger.info("┌┬┐┌─┐┌┬┐┌┬┐┌─┐┬┬")
+        logger.info("││││ │ │││││├─┤││")
+        logger.info("┴ ┴└─┘─┴┘┴ ┴┴ ┴┴┴─┘")
         logger.info("v%s", __version__)
         logger.info("Authors: kyb3r, fourjr, Taaku18")
         logger.line()

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -393,6 +393,7 @@ class Utility(commands.Cog):
                 os.path.dirname(os.path.abspath(__file__)), f"../temp/{log_file_name}.log"
             ),
             "r+",
+            encoding="utf-8",
         ) as f:
             logs = f.read().strip()
 
@@ -448,6 +449,7 @@ class Utility(commands.Cog):
                 os.path.dirname(os.path.abspath(__file__)), f"../temp/{log_file_name}.log"
             ),
             "rb+",
+            encoding="utf-8",
         ) as f:
             logs = BytesIO(f.read().strip())
 

--- a/core/models.py
+++ b/core/models.py
@@ -127,7 +127,7 @@ class FileFormatter(logging.Formatter):
 
 def configure_logging(name, level=None):
     global ch_debug, log_level
-    ch_debug = RotatingFileHandler(name, mode="a+", maxBytes=48000, backupCount=1)
+    ch_debug = RotatingFileHandler(name, mode="a+", maxBytes=48000, backupCount=1, encoding="utf-8")
 
     formatter_debug = FileFormatter(
         "%(asctime)s %(name)s[%(lineno)d] - %(levelname)s: %(message)s",

--- a/core/models.py
+++ b/core/models.py
@@ -127,7 +127,9 @@ class FileFormatter(logging.Formatter):
 
 def configure_logging(name, level=None):
     global ch_debug, log_level
-    ch_debug = RotatingFileHandler(name, mode="a+", maxBytes=48000, backupCount=1, encoding="utf-8")
+    ch_debug = RotatingFileHandler(
+        name, mode="a+", maxBytes=48000, backupCount=1, encoding="utf-8"
+    )
 
     formatter_debug = FileFormatter(
         "%(asctime)s %(name)s[%(lineno)d] - %(levelname)s: %(message)s",


### PR DESCRIPTION
__**About this PR:**__
- Fix missing argument in method `convert_emoji` in file `bot.py`.
- Fix UnicodeEncodeError (for Windows users) when logging unicode emojis or special characters.