### PR TITLE
Hotfix: Deleting messages for thread recipients

### DIFF
--- a/core/thread.py
+++ b/core/thread.py
@@ -697,10 +697,10 @@ class Thread:
         tasks = []
         if not isinstance(message, discord.Message):
             tasks += [message1.delete()]
-        elif message2 is not [None]:
+        if message2 is not [None]:
             for m2 in message2:
                 tasks += [m2.delete()]
-        elif message1.embeds[0].author.name.startswith("Persistent Note"):
+        if message1.embeds[0].author.name.startswith("Persistent Note"):
             tasks += [self.bot.api.delete_note(message1.id)]
         if tasks:
             await asyncio.gather(*tasks)


### PR DESCRIPTION
reverted https://github.com/kyb3r/modmail/commit/beb73d8d82960429631c0aef5aea31f4f75f23b1
this causes messages to not delete in dm channels