### PR TITLE
Update modmail.py

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -537,7 +537,7 @@ class Modmail(commands.Cog):
         if mention in mentions:
             embed = discord.Embed(
                 color=self.bot.error_color,
-                description=f"{mention} is not subscribed to this thread.",
+                description=f"{mention} is already subscribed to this thread.",
             )
         else:
             mentions.append(mention)
@@ -575,7 +575,7 @@ class Modmail(commands.Cog):
         if mention not in mentions:
             embed = discord.Embed(
                 color=self.bot.error_color,
-                description=f"{mention} is not subscribed to this thread.",
+                description=f"{mention} is already subscribed to this thread.",
             )
         else:
             mentions.remove(mention)


### PR DESCRIPTION
When ?sub is used by someone the bot says "(mention) is not subscribed to this thread" instead of "(mention) is already subscribed to the thread". Fixed it.