### PR TITLE
Add Python Discord's plugins to the registry

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -1,4 +1,49 @@
 {
+    "case_insensitive_snippets": {
+        "repository": "python-discord/modmail-plugins",
+        "branch": "main",
+        "description": "Allow snippets to be ran even if with the wrong case. For example, ?Dm-RePort will be recognized as ?dm-report.",
+        "bot_version": "2.20.1",
+        "title": "Case insensitive snippets",
+        "icon_url": "https://i.imgur.com/kaJYlMB.png",
+        "thumbnail_url": "https://i.imgur.com/kaJYlMB.png"
+    },
+    "close_message": {
+        "repository": "python-discord/modmail-plugins",
+        "branch": "main",
+        "description": "Add a ?closemessage command that will close the thread after 15 minutes with a default message.",
+        "bot_version": "2.20.1",
+        "title": "Close message",
+        "icon_url": "https://i.imgur.com/ev7BFMz.png",
+        "thumbnail_url": "https://i.imgur.com/ev7BFMz.png"
+    },
+    "mdlink": {
+        "repository": "python-discord/modmail-plugins",
+        "branch": "main",
+        "description": "Generate a ready to paste link to the thread logs.",
+        "bot_version": "2.20.1",
+        "title": "MDLink",
+        "icon_url": "https://i.imgur.com/JA2E63R.png",
+        "thumbnail_url": "https://i.imgur.com/JA2E63R.png"
+    },
+    "reply_cooldown": {
+        "repository": "python-discord/modmail-plugins",
+        "branch": "main",
+        "description": "Forbid you from sending the same message twice in ten seconds.",
+        "bot_version": "2.20.1",
+        "title": "Reply cooldown",
+        "icon_url": "https://i.imgur.com/FtRQveT.png",
+        "thumbnail_url": "https://i.imgur.com/FtRQveT.png"
+    },
+    "tagging": {
+        "repository": "python-discord/modmail-plugins",
+        "branch": "main",
+        "description": "Add a ?tag command capable of adding a $message｜ header to the channel name.",
+        "bot_version": "2.20.1",
+        "title": "Tagging",
+        "icon_url": "https://i.imgur.com/WajSLB1.png",
+        "thumbnail_url": "https://i.imgur.com/WajSLB1.png"
+    },
     "dragory-migrate": {
         "repository": "kyb3r/modmail-plugins",
         "branch": "master",

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -1,13 +1,4 @@
 {
-    "case_insensitive_snippets": {
-        "repository": "python-discord/modmail-plugins",
-        "branch": "main",
-        "description": "Allow snippets to be ran even if with the wrong case. For example, ?Dm-RePort will be recognized as ?dm-report.",
-        "bot_version": "2.20.1",
-        "title": "Case insensitive snippets",
-        "icon_url": "https://i.imgur.com/kaJYlMB.png",
-        "thumbnail_url": "https://i.imgur.com/kaJYlMB.png"
-    },
     "close_message": {
         "repository": "python-discord/modmail-plugins",
         "branch": "main",
@@ -34,15 +25,6 @@
         "title": "Reply cooldown",
         "icon_url": "https://i.imgur.com/FtRQveT.png",
         "thumbnail_url": "https://i.imgur.com/FtRQveT.png"
-    },
-    "tagging": {
-        "repository": "python-discord/modmail-plugins",
-        "branch": "main",
-        "description": "Add a ?tag command capable of adding a $message｜ header to the channel name.",
-        "bot_version": "2.20.1",
-        "title": "Tagging",
-        "icon_url": "https://i.imgur.com/WajSLB1.png",
-        "thumbnail_url": "https://i.imgur.com/WajSLB1.png"
     },
     "dragory-migrate": {
         "repository": "kyb3r/modmail-plugins",


### PR DESCRIPTION
This PR adds the following plugins:
- **Case insensitive snippets**: Allow snippets to be ran even if with the wrong case. For example, `?Dm-RePort` will be recognized as `?dm-report`.
- **Close message:** Add a `?closemessage` command that will close the thread after 15 minutes with a default message.
- **MDLink**: Generate a ready to paste link to the thread logs.
- **Reply cooldown**: Forbid you from sending the same message twice in ten seconds.
- **Tagging**: Add a `?tag` command capable of adding a `$message｜` header to the channel name.

The source code can be found in [our repository](https://git.pydis.com/modmail-plugins). I have the authorisation from all the authors to create this PR.