### PR TITLE
Fix `?contact` command bug where the channel is created inside random category.

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1362,9 +1362,16 @@ class Modmail(commands.Cog):
         """
         silent = False
         if isinstance(category, str):
-            if "silent" in category or "silently" in category:
+            category = category.split()
+
+            # just check the last element in the list
+            if category[-1].lower() in ("silent", "silently"):
                 silent = True
-                category = category.strip("silently").strip("silent").strip()
+                # remove the last element as we no longer need it
+                category.pop()
+
+            category = " ".join(category)
+            if category:
                 try:
                     category = await SimilarCategoryConverter().convert(
                         ctx, category


### PR DESCRIPTION
__**About this PR:**__
- Fix `?contact` command bug where the bot creates the thread channel inside a random category if `silent` or `silently` is passed in the command.

Resolve #3091

The cause of the issue is, there's a possibility an empty string is passed when converting the category using the `SimilarCategoryConverter` that makes the converter returns any category it found first.
I think the solution in this PR is dynamic enough to deal with that and user inputs.