### PR TITLE
Allow get_top_role to be optionally hoisted via config.

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -918,7 +918,7 @@ class Modmail(commands.Cog):
 
             tag = self.bot.config["mod_tag"]
             if tag is None:
-                tag = str(get_top_hoisted_role(ctx.author))
+                tag = str(get_top_role(ctx.author, self.bot.config["use_hoisted_top_role"]))
             name = self.bot.config["anon_username"]
             if name is None:
                 name = tag
@@ -1003,7 +1003,7 @@ class Modmail(commands.Cog):
 
             tag = self.bot.config["mod_tag"]
             if tag is None:
-                tag = str(get_top_hoisted_role(ctx.author))
+                tag = str(get_top_role(ctx.author, self.bot.config["use_hoisted_top_role"]))
             name = self.bot.config["anon_username"]
             if name is None:
                 name = tag

--- a/core/config.py
+++ b/core/config.py
@@ -123,6 +123,7 @@ class ConfigManager:
         "confirm_thread_creation_deny": "\N{NO ENTRY SIGN}",
         # regex
         "use_regex_autotrigger": False,
+        "use_hoisted_top_role": True,
     }
 
     private_keys = {
@@ -209,6 +210,7 @@ class ConfigManager:
         "thread_show_roles",
         "thread_show_account_age",
         "thread_show_join_age",
+        "use_hoisted_top_role",
     }
 
     enums = {

--- a/core/config_help.json
+++ b/core/config_help.json
@@ -1121,5 +1121,16 @@
     "notes": [
       "This configuration can only to be set through `.env` file or environment (config) variables."
     ]
+  },
+  "use_hoisted_top_role": {
+    "default": "Yes",
+    "description": "Controls if only hoisted roles are evaluated when finding top role.",
+    "examples": [
+    ],
+    "notes": [
+      "Top role is displayed in embeds when replying or adding/removing users to a thread in the case mod_tag and anon_username are not set.",
+      "If this configuration is enabled, only roles that are hoisted (displayed seperately in member list) will be used. If a user has no hoisted roles, it will return 'None'.",
+      "If you would like to display the top role of a user regardless of if it's hoisted or not, disable `use_hoisted_top_role`."
+    ]
   }
 }

--- a/core/thread.py
+++ b/core/thread.py
@@ -21,7 +21,7 @@ from core.utils import (
     match_user_id,
     match_other_recipients,
     truncate,
-    get_top_hoisted_role,
+    get_top_role,
     create_thread_channel,
     get_joint_id,
 )
@@ -938,7 +938,7 @@ class Thread:
                 # Anonymously sending to the user.
                 tag = self.bot.config["mod_tag"]
                 if tag is None:
-                    tag = str(get_top_hoisted_role(author))
+                    tag = str(get_top_role(author, self.bot.config["use_hoisted_top_role"]))
                 name = self.bot.config["anon_username"]
                 if name is None:
                     name = tag
@@ -1055,7 +1055,7 @@ class Thread:
             elif not anonymous:
                 mod_tag = self.bot.config["mod_tag"]
                 if mod_tag is None:
-                    mod_tag = str(get_top_hoisted_role(message.author))
+                    mod_tag = str(get_top_role(message.author, self.bot.config["use_hoisted_top_role"]))
                 embed.set_footer(text=mod_tag)  # Normal messages
             else:
                 embed.set_footer(text=self.bot.config["anon_tag"])

--- a/core/utils.py
+++ b/core/utils.py
@@ -30,7 +30,7 @@ __all__ = [
     "trigger_typing",
     "escape_code_block",
     "tryint",
-    "get_top_hoisted_role",
+    "get_top_role",
     "get_joint_id",
 ]
 
@@ -369,9 +369,11 @@ def tryint(x):
         return x
 
 
-def get_top_hoisted_role(member: discord.Member):
+def get_top_role(member: discord.Member, hoisted=True):
     roles = sorted(member.roles, key=lambda r: r.position, reverse=True)
     for role in roles:
+        if not hoisted:
+            return role
         if role.hoist:
             return role
 


### PR DESCRIPTION
PR #3014 introduced the behavior to only fetch hoisted top roles, which may be fine for most, but is an unexpected behavior to those who may have a secondary mod-mail server that doesn't bother to hoist the roles, and may specifically not wish to.

The result of no hoisted roles is predictably None being sent for anon reply titles and mod_tag reply footers.

![image](https://user-images.githubusercontent.com/29337040/132280677-b7b21ef7-2c95-45c0-8ecd-58d7c05f0779.png)
![image](https://user-images.githubusercontent.com/29337040/132280689-424e7aa4-8a38-43c9-8ed6-5ef4b9908d04.png)

In this PR, I've set this behavior to be configurable through a new config key: `use_hoisted_top_role`. Considering the majority of setups will be fine with it as-is, I've set it to True by default. 

I chose to use a simple `hoisted` flag on the util function rather than requiring `bot` be passed just to reference the config. This will also ensure the utility can be used in a generic manner in future for cases that may not want to rely on the same configuration value.