### PR TITLE
Kill Command

### DIFF
--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -266,6 +266,7 @@ class Utility(commands.Cog):
     def cog_unload(self):
         self.bot.help_command = self._original_help_command
 
+    @commands.command()
     @checks.has_permissions_predicate(PermissionLevel.OWNER)
     async def killbot(self, ctx):
         await ctx.send("Goodbye!")

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -1,6 +1,7 @@
 import asyncio
 import inspect
 import os
+import sys
 import random
 import re
 import traceback
@@ -265,6 +266,11 @@ class Utility(commands.Cog):
     def cog_unload(self):
         self.bot.help_command = self._original_help_command
 
+    @checks.has_permissions_predicate(PermissionLevel.OWNER)
+    async def killbot(self, ctx):
+        await ctx.send("Goodbye!")
+        sys.exit(0)
+    
     @commands.command()
     @checks.has_permissions(PermissionLevel.REGULAR)
     @utils.trigger_typing


### PR DESCRIPTION
This isn't much but it's just a simple way of killing the bot without the use of eval. (For those who don't know how to use Python yet) It's also a very simple way of ending the bot incase you need to do some maintenance. 