### PR TITLE
Add a utility to get/fetch a user and use it when closing pending threads.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -582,7 +582,7 @@ class ModmailBot(commands.Bot):
                 continue
 
             await thread.close(
-                closer=self.get_user(items["closer_id"]),
+                closer=self.get_user(items["closer_id"]) or await self.fetch_user(items["closer_id"]),
                 after=after,
                 silent=items["silent"],
                 delete_channel=items["delete_channel"],

--- a/bot.py
+++ b/bot.py
@@ -582,7 +582,7 @@ class ModmailBot(commands.Bot):
                 continue
 
             await thread.close(
-                closer=self.get_user(items["closer_id"]) or await self.fetch_user(items["closer_id"]),
+                closer=await self.get_or_fetch_user(items["closer_id"]),
                 after=after,
                 silent=items["silent"],
                 delete_channel=items["delete_channel"],

--- a/bot.py
+++ b/bot.py
@@ -656,6 +656,15 @@ class ModmailBot(commands.Bot):
                 raise
         return name
 
+    async def get_or_fetch_user(self, id: int) -> discord.User:
+        """
+        Retrieve a User based on their ID.
+
+        This tries getting the user from the cache and falls back to making
+        an API call if they're not found in the cache.
+        """
+        return self.get_user(id) or await self.fetch_user(id)
+
     async def retrieve_emoji(self) -> typing.Tuple[str, str]:
 
         sent_emoji = self.config["sent_emoji"]

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1042,7 +1042,7 @@ class Modmail(commands.Cog):
             thread = ctx.thread
             if not thread:
                 raise commands.MissingRequiredArgument(SimpleNamespace(name="member"))
-            user = thread.recipient or await self.bot.fetch_user(thread.id)
+            user = thread.recipient or await self.bot.get_or_fetch_user(thread.id)
 
         default_avatar = "https://cdn.discordapp.com/embed/avatars/0.png"
         icon_url = getattr(user, "avatar_url", default_avatar)
@@ -1492,15 +1492,12 @@ class Modmail(commands.Cog):
                     logger.debug("No longer blocked, user %s.", id_)
                     continue
 
-            user = self.bot.get_user(int(id_))
-            if user:
-                users.append((user.mention, reason))
+            try:
+                user = await self.bot.get_or_fetch_user(int(id_))
+            except discord.NotFound:
+                users.append((id_, reason))
             else:
-                try:
-                    user = await self.bot.fetch_user(id_)
-                    users.append((user.mention, reason))
-                except discord.NotFound:
-                    users.append((id_, reason))
+                users.append((user.mention, reason))
 
         blocked_roles = list(self.bot.blocked_roles.items())
         for id_, reason in blocked_roles:
@@ -1840,7 +1837,7 @@ class Modmail(commands.Cog):
                 user_id = match_user_id(message.embeds[0].footer.text)
                 other_recipients = match_other_recipients(ctx.channel.topic)
                 for n, uid in enumerate(other_recipients):
-                    other_recipients[n] = self.bot.get_user(uid) or await self.bot.fetch_user(uid)
+                    other_recipients[n] = await self.bot.get_or_fetch_user(uid)
 
                 if user_id != -1:
                     recipient = self.bot.get_user(user_id)
@@ -1893,7 +1890,7 @@ class Modmail(commands.Cog):
 
                 other_recipients = match_other_recipients(ctx.channel.topic)
                 for n, uid in enumerate(other_recipients):
-                    other_recipients[n] = self.bot.get_user(uid) or await self.bot.fetch_user(uid)
+                    other_recipients[n] = await self.bot.get_or_fetch_user(uid)
 
                 if recipient is None:
                     self.bot.threads.cache[user.id] = thread = Thread(

--- a/core/thread.py
+++ b/core/thread.py
@@ -126,12 +126,12 @@ class Thread:
         if recipient_id in manager.cache:
             thread = manager.cache[recipient_id]
         else:
-            recipient = manager.bot.get_user(recipient_id) or await manager.bot.fetch_user(recipient_id)
+            recipient = await manager.bot.get_or_fetch_user(recipient_id)
 
             other_recipients = []
             for uid in match_other_recipients(channel.topic):
                 try:
-                    other_recipient = manager.bot.get_user(uid) or await manager.bot.fetch_user(uid)
+                    other_recipient = await manager.bot.get_or_fetch_user(uid)
                 except discord.NotFound:
                     continue
                 other_recipients.append(other_recipient)
@@ -1243,14 +1243,14 @@ class ThreadManager:
             return self.cache[user_id]
 
         try:
-            recipient = self.bot.get_user(user_id) or await self.bot.fetch_user(user_id)
+            recipient = await self.bot.get_or_fetch_user(user_id)
         except discord.NotFound:
             recipient = None
 
         other_recipients = []
         for uid in match_other_recipients(channel.topic):
             try:
-                other_recipient = self.bot.get_user(uid) or await self.bot.fetch_user(uid)
+                other_recipient = await self.bot.get_or_fetch_user(uid)
             except discord.NotFound:
                 continue
             other_recipients.append(other_recipient)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,5 +34,5 @@ repository = 'https://github.com/kyb3r/modmail'
 homepage = 'https://github.com/kyb3r/modmail'
 keywords = ['discord', 'modmail']
 
-[tool.pylint.format]react_to_contact_message
+[tool.pylint.format]
 max-line-length = "110"


### PR DESCRIPTION
Closes #3104.

I noticed we frequently use something like `bot.get_user(id) or await bot.fetch_user(id)` and extracted that to a utility function to avoid repetition and keep stuff tidy.