### PR TITLE
Fix the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9-slim as py
 
 FROM py as build
 
-RUN apt update && apt install -y g++
+RUN apt update && apt install -y g++ git
 COPY requirements.txt /
 RUN pip install --prefix=/inst -U -r /requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim as py
+FROM python:3.9 as py
 
 FROM py as build
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,21 +9,31 @@
 aiohttp==3.7.4.post0
 async-timeout==3.0.1; python_full_version >= '3.5.3'
 attrs==21.2.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+cairocffi==1.3.0; python_version >= '3.7'
+cairosvg==2.5.2; python_version >= '3.5'
+cffi==1.15.0
 chardet==4.0.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 colorama==0.4.4
+cssselect2==0.4.1; python_version >= '3.6'
+defusedxml==0.7.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 dnspython==2.1.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 emoji==1.2.0
 git+https://github.com/Rapptz/discord.py.git@45d498c1b76deaf3b394d17ccf56112fa691d160#egg=discord-py
 idna==3.3; python_version >= '3.5'
 isodate==0.6.0
+lottie[pdf]==0.6.10
 motor==2.4.0
 multidict==5.2.0; python_version >= '3.6'
 natural==0.2.0
 parsedatetime==2.6
+pillow==8.4.0; python_version >= '3.6'
+pycparser==2.21
 pymongo[srv]==3.12.1
 python-dateutil==2.8.2
 python-dotenv==0.18.0
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+tinycss2==1.1.0; python_version >= '3.6'
 typing-extensions==4.0.0; python_version >= '3.6'
 uvloop==0.16.0; sys_platform != 'win32'
+webencodings==0.5.1
 yarl==1.7.2; python_version >= '3.6'


### PR DESCRIPTION
Since discord.py is installed via git in requirements.txt the Dockerfile needs to have git installed to download it.

Also, since lottie was added, to support stickers, this bumps the requirements, so they are available within the image.