### PR TITLE
User ID topic is set on thread creation now. Fix for #3152

### DIFF
--- a/core/thread.py
+++ b/core/thread.py
@@ -196,7 +196,6 @@ class Thread:
             log_url = log_count = None
             # ensure core functionality still works
 
-        await channel.edit(topic=f"User ID: {recipient.id}")
         self.ready = True
 
         if creator is not None and creator != recipient:

--- a/core/utils.py
+++ b/core/utils.py
@@ -432,6 +432,7 @@ async def create_thread_channel(bot, recipient, category, overwrites, *, name=No
             name=name,
             category=category,
             overwrites=overwrites,
+            topic=f"User ID: {recipient.id}",
             reason="Creating a thread channel.",
         )
     except discord.HTTPException as e:


### PR DESCRIPTION
It is an extra API call to separately set the channel topic instead of passing it when creating. This issue was described in #3152