### PR TITLE
Fix Future attached to different loop, issue #3165

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -71,7 +71,7 @@ class ModmailBot(commands.Bot):
         self._api = None
         self.formatter = SafeFormatter()
         self.loaded_cogs = ["cogs.modmail", "cogs.plugins", "cogs.utility"]
-        self._connected = asyncio.Event()
+        self._connected = None
         self.start_time = discord.utils.utcnow()
         self._started = False
 
@@ -213,6 +213,7 @@ class ModmailBot(commands.Bot):
     def run(self):
         async def runner():
             async with self:
+                self._connected = asyncio.Event()
                 self.session = ClientSession(loop=self.loop)
                 try:
                     retry_intents = False


### PR DESCRIPTION
This PR fixes the `Future <Future pending> attached to a different loop` as described in #3165.

__**Explaination:**__
I'm not really sure about this, but from what I figured, the `asyncio.Event()` was instantiated in `__init__` while the `ModmailBot` instance was created outside the async function (in `main()`):
https://github.com/kyb3r/modmail/blob/77489be6a21cf4befeab1dc7fa2c2d2098104cbc/bot.py#L1771
That makes the bot create a different loop (from the one that has already been created by `asyncio.Event` when instantiating the bot) when calling `.run()` as it enters the async context manager (`async with...`).

This PR fixes that by instantiatng the `asyncio.Event()` after the bot enters the async context manager.