### PR TITLE
Add `unhandled_by_cog` parameter to `ModmailBot.on_command_error`

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1511,7 +1511,17 @@ class ModmailBot(commands.Bot):
         logger.error("Ignoring exception in %s.", event_method)
         logger.error("Unexpected exception:", exc_info=sys.exc_info())
 
-    async def on_command_error(self, context, exception):
+    async def on_command_error(
+        self, context: commands.Context, exception: Exception, *, unhandled_by_cog: bool = False
+    ) -> None:
+        if not unhandled_by_cog:
+            command = context.command
+            if command and command.has_error_handler():
+                return
+            cog = context.cog
+            if cog and cog.has_error_handler():
+                return
+
         if isinstance(exception, (commands.BadArgument, commands.BadUnionArgument)):
             await context.typing()
             await context.send(embed=discord.Embed(color=self.error_color, description=str(exception)))


### PR DESCRIPTION
- Resolve #3170

As per title, this allows plugin developers to have their own custom exceptions and have more control on how to handle errors from their plugins without flooding the console, etc.

Example in plugin file:
- Specific command error handler.
```py
# imports

class MyPlugin(commands.Cog):
    def __init__(self, bot):
        self.bot = bot

    @commands.command()
    @checks.has_permissions(PermissionLevel.OWNER)
    async def test(self, ctx, *, value: str = None):
        if value == "1":
            raise TypeError("TypeError.")
        elif value == "2":
            raise commands.BadArgument("BadArgument.")
        else:
            await ctx.send("None.")

    @test.error
    async def test_error(self, ctx, error):
        if hasattr(error, "original"):
            # usually (I'm not really sure of this) if the exception is raised inside the command and the type of exception is not inherited
            # from .CommandError, the type of error here would be .CommandInvokeError and the original exception
            # can be retrieved from the .original attribute.
            error = error.original
        if isinstance(error, TypeError):
            await ctx.send(str(error))
        else:
            await self.bot.on_command_error(ctx, error, unhandled_by_cog=True)
```

- Cog error handler, this will catch every command error raised from the plugin.
```py
# imports

class MyPlugin(commands.Cog):
    def __init__(self, bot):
        self.bot = bot

    @commands.command()
    @checks.has_permissions(PermissionLevel.OWNER)
    async def test(self, ctx, *, value: str = None):
        if value == "1":
            raise TypeError("TypeError.")
        elif value == "2":
            raise commands.BadArgument("BadArgument.")
        else:
            await ctx.send("None.")

    async def cog_command_error(self, ctx, error):
        if hasattr(error, "original"):
            error = error.original
        if isinstance(error, TypeError):
            await ctx.send(str(error))
        else:
            await self.bot.on_command_error(ctx, error, unhandled_by_cog=True)
```