### PR TITLE
Add a command `logs id`

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1218,7 +1218,6 @@ class Modmail(commands.Cog):
         """
         Get the log link for the specified log ID
         """        
-        default_avatar = "https://cdn.discordapp.com/embed/avatars/0.png"
         icon_url = ctx.author.avatar.url
         
         logs = await self.bot.api.find_log_entry(key)

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1211,15 +1211,15 @@ class Modmail(commands.Cog):
 
         session = EmbedPaginatorSession(ctx, *embeds)
         await session.run()
-        
+
     @logs.command(name="id")
     @checks.has_permissions(PermissionLevel.SUPPORTER)
     async def logs_id(self, ctx, key: str):
         """
         Get the log link for the specified log ID
-        """        
+        """
         icon_url = ctx.author.avatar.url
-        
+
         logs = await self.bot.api.find_log_entry(key)
 
         if not any(not log["open"] for log in logs):

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1211,6 +1211,31 @@ class Modmail(commands.Cog):
 
         session = EmbedPaginatorSession(ctx, *embeds)
         await session.run()
+        
+    @logs.command(name="id")
+    @checks.has_permissions(PermissionLevel.SUPPORTER)
+    async def logs_id(self, ctx, key: str):
+        """
+        Get the log link for the specified log ID
+        """        
+        default_avatar = "https://cdn.discordapp.com/embed/avatars/0.png"
+        icon_url = ctx.author.avatar.url
+        
+        logs = await self.bot.api.find_log_entry(key)
+
+        if not any(not log["open"] for log in logs):
+            embed = discord.Embed(
+                color=self.bot.error_color,
+                description=f"Log entry `{key}` not found.",
+            )
+            return await ctx.send(embed=embed)
+
+        logs = reversed([log for log in logs if not log["open"]])
+
+        embeds = self.format_log_embeds(logs, avatar_url=icon_url)
+
+        session = EmbedPaginatorSession(ctx, *embeds)
+        await session.run()
 
     @logs.command(name="delete", aliases=["wipe"])
     @checks.has_permissions(PermissionLevel.OWNER)

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1230,7 +1230,7 @@ class Modmail(commands.Cog):
             )
             return await ctx.send(embed=embed)
 
-        logs = reversed([log for log in logs if not log["open"]])
+        logs = reversed(log for log in logs if not log["open"])
 
         embeds = self.format_log_embeds(logs, avatar_url=icon_url)
 

--- a/core/clients.py
+++ b/core/clients.py
@@ -355,6 +355,9 @@ class ApiClient:
 
     async def get_user_logs(self, user_id: Union[str, int]) -> list:
         return NotImplemented
+    
+    async def find_log_entry(self, key: str) -> list:
+        return NotImplemented
 
     async def get_latest_user_logs(self, user_id: Union[str, int]):
         return NotImplemented
@@ -526,6 +529,13 @@ class MongoDBClient(ApiClient):
         query = {"recipient.id": str(user_id), "guild_id": str(self.bot.guild_id)}
         projection = {"messages": {"$slice": 5}}
         logger.debug("Retrieving user %s logs.", user_id)
+
+        return await self.logs.find(query, projection).to_list(None)
+    
+    async def find_log_entry(self, key: str) -> list:
+        query = {"key": key}
+        projection = {"messages": {"$slice": 5}}
+        logger.debug(f"Retrieving log ID {key}.")
 
         return await self.logs.find(query, projection).to_list(None)
 

--- a/core/clients.py
+++ b/core/clients.py
@@ -7,6 +7,7 @@ import discord
 from discord import Member, DMChannel, TextChannel, Message
 from discord.ext import commands
 
+p
 from aiohttp import ClientResponseError, ClientResponse
 from motor.motor_asyncio import AsyncIOMotorClient
 from pymongo.errors import ConfigurationError
@@ -355,7 +356,7 @@ class ApiClient:
 
     async def get_user_logs(self, user_id: Union[str, int]) -> list:
         return NotImplemented
-    
+
     async def find_log_entry(self, key: str) -> list:
         return NotImplemented
 
@@ -531,7 +532,7 @@ class MongoDBClient(ApiClient):
         logger.debug("Retrieving user %s logs.", user_id)
 
         return await self.logs.find(query, projection).to_list(None)
-    
+
     async def find_log_entry(self, key: str) -> list:
         query = {"key": key}
         projection = {"messages": {"$slice": 5}}

--- a/core/clients.py
+++ b/core/clients.py
@@ -7,7 +7,7 @@ import discord
 from discord import Member, DMChannel, TextChannel, Message
 from discord.ext import commands
 
-p
+
 from aiohttp import ClientResponseError, ClientResponse
 from motor.motor_asyncio import AsyncIOMotorClient
 from pymongo.errors import ConfigurationError

--- a/core/thread.py
+++ b/core/thread.py
@@ -1163,7 +1163,7 @@ class Thread:
                 msg = await destination.send(plain_message, files=files)
             else:
                 # Plain to mods
-                embed.set_footer(text="[PLAIN] " + embed.footer.text)
+                embed.set_footer(text="[PLAIN] " + ctx.msg.id + embed.footer.text)
                 msg = await destination.send(mentions, embed=embed)
 
         else:

--- a/core/thread.py
+++ b/core/thread.py
@@ -1163,7 +1163,7 @@ class Thread:
                 msg = await destination.send(plain_message, files=files)
             else:
                 # Plain to mods
-                embed.set_footer(text="[PLAIN] " + ctx.msg.id + embed.footer.text)
+                embed.set_footer(text="[PLAIN] " + msg.id + embed.footer.text)
                 msg = await destination.send(mentions, embed=embed)
 
         else:

--- a/core/thread.py
+++ b/core/thread.py
@@ -1161,9 +1161,10 @@ class Thread:
                     files.append(await i.to_file())
 
                 msg = await destination.send(plain_message, files=files)
+                msg_id = msg.id
             else:
                 # Plain to mods
-                embed.set_footer(text="[PLAIN] " + msg.id + embed.footer.text)
+                embed.set_footer(text="[PLAIN] " + msg_id + embed.footer.text)
                 msg = await destination.send(mentions, embed=embed)
 
         else:


### PR DESCRIPTION
Added command `logs id <key>`, this helps users locate the log link / preview if they just have the log id. 

This will help once a Heroku alternative is found and users log link changes due to moving from Heroku. They can use this command to bring up the new link easily

Have tested this. 