### PR TITLE
Add a command `logs id`

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1211,6 +1211,31 @@ class Modmail(commands.Cog):
 
         session = EmbedPaginatorSession(ctx, *embeds)
         await session.run()
+        
+    @logs.command(name="id")
+    @checks.has_permissions(PermissionLevel.SUPPORTER)
+    async def logs_id(self, ctx, key: str):
+        """
+        Get the log link for the specified log ID
+        """
+        icon_url = ctx.author.avatar.url
+
+        logs = await self.bot.api.find_log_entry(key)
+
+        if not any(not log["open"] for log in logs):
+            embed = discord.Embed(
+                color=self.bot.error_color,
+                description=f"Log entry `{key}` not found.",
+            )
+            return await ctx.send(embed=embed)
+
+        logs = reversed(log for log in logs if not log["open"])
+
+        embeds = self.format_log_embeds(logs, avatar_url=icon_url)
+
+        session = EmbedPaginatorSession(ctx, *embeds)
+        await session.run()
+
 
     @logs.command(name="delete", aliases=["wipe"])
     @checks.has_permissions(PermissionLevel.OWNER)

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1211,7 +1211,7 @@ class Modmail(commands.Cog):
 
         session = EmbedPaginatorSession(ctx, *embeds)
         await session.run()
-        
+
     @logs.command(name="id")
     @checks.has_permissions(PermissionLevel.SUPPORTER)
     async def logs_id(self, ctx, key: str):
@@ -1235,7 +1235,6 @@ class Modmail(commands.Cog):
 
         session = EmbedPaginatorSession(ctx, *embeds)
         await session.run()
-
 
     @logs.command(name="delete", aliases=["wipe"])
     @checks.has_permissions(PermissionLevel.OWNER)

--- a/core/clients.py
+++ b/core/clients.py
@@ -355,6 +355,9 @@ class ApiClient:
 
     async def get_user_logs(self, user_id: Union[str, int]) -> list:
         return NotImplemented
+    
+    async def find_log_entry(self, key: str) -> list:
+        return NotImplemented
 
     async def get_latest_user_logs(self, user_id: Union[str, int]):
         return NotImplemented
@@ -526,6 +529,13 @@ class MongoDBClient(ApiClient):
         query = {"recipient.id": str(user_id), "guild_id": str(self.bot.guild_id)}
         projection = {"messages": {"$slice": 5}}
         logger.debug("Retrieving user %s logs.", user_id)
+
+        return await self.logs.find(query, projection).to_list(None)
+    
+    async def find_log_entry(self, key: str) -> list:
+        query = {"key": key}
+        projection = {"messages": {"$slice": 5}}
+        logger.debug(f"Retrieving log ID {key}.")
 
         return await self.logs.find(query, projection).to_list(None)
 

--- a/core/clients.py
+++ b/core/clients.py
@@ -355,7 +355,7 @@ class ApiClient:
 
     async def get_user_logs(self, user_id: Union[str, int]) -> list:
         return NotImplemented
-    
+
     async def find_log_entry(self, key: str) -> list:
         return NotImplemented
 
@@ -531,7 +531,7 @@ class MongoDBClient(ApiClient):
         logger.debug("Retrieving user %s logs.", user_id)
 
         return await self.logs.find(query, projection).to_list(None)
-    
+
     async def find_log_entry(self, key: str) -> list:
         query = {"key": key}
         projection = {"messages": {"$slice": 5}}


### PR DESCRIPTION
Added command `logs id <key>`, this helps users locate the log link / preview if they just have the log id.

This will help once a Heroku alternative is found and users log link changes due to moving from Heroku. They can use this command to bring up the new link easily

Have tested this.

Remade the PR because I was testing something on the same branch and it uh clogged up stuff. 