### PR TITLE
Dockerfile to use Python3.10 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9 as py
+FROM python:3.10 as py
 
 FROM py as build
 


### PR DESCRIPTION
This is to maintain consistency with runtime.txt

Refer to PR #3197 