### PR TITLE
Added advanced menu to registry

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -1,4 +1,13 @@
 {
+    "advanced-menu": {
+        "repository": "sebkuip/mm-plugins",
+        "branch": "master",
+        "description": "Advanced menu plugin using dropdown selectors. Supports submenus (and sub-submenus infinitely).",
+        "bot_version": "v4.0.0",
+        "title": "Advanced menu",
+        "icon_url": "https://raw.githubusercontent.com/sebkuip/mm-plugins/master/advanced-menu/logo.png",
+        "thumbnail_url": "https://raw.githubusercontent.com/sebkuip/mm-plugins/master/advanced-menu/logo.png"
+    },
     "suggest": {
         "repository": "realcyguy/modmail-plugins",
         "branch": "v4",


### PR DESCRIPTION
This plugin adds menus, and submenus (and sub-submenus indefinitely) using discord's built-in dropdown selector.
It is highly customizable, and effort has been put in to make the usage as smooth as possible.