### PR TITLE
Fix issue where commands dont work if guild icon doesnt exist GH#3205

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -914,7 +914,7 @@ class ModmailBot(commands.Bot):
                     description=self.config["disabled_new_thread_response"],
                 )
                 embed.set_footer(
-                    text=self.config["disabled_new_thread_footer"], icon_url=self.bot.api.get_guild_icon()
+                    text=self.config["disabled_new_thread_footer"], icon_url=await self.bot.api.get_guild_icon()
                 )
                 logger.info("A new thread was blocked from %s due to disabled Modmail.", message.author)
                 await self.add_reaction(message, blocked_emoji)
@@ -930,7 +930,7 @@ class ModmailBot(commands.Bot):
                 )
                 embed.set_footer(
                     text=self.config["disabled_current_thread_footer"],
-                    icon_url=self.bot.api.get_guild_icon(),
+                    icon_url=await self.bot.api.get_guild_icon(),
                 )
                 logger.info("A message was blocked from %s due to disabled Modmail.", message.author)
                 await self.add_reaction(message, blocked_emoji)
@@ -1337,7 +1337,7 @@ class ModmailBot(commands.Bot):
             )
             embed.set_footer(
                 text=self.config["disabled_new_thread_footer"],
-                icon_url=self.bot.api.get_guild_icon(),
+                icon_url=await self.bot.api.get_guild_icon(),
             )
             logger.info(
                 "A new thread using react to contact was blocked from %s due to disabled Modmail.",

--- a/bot.py
+++ b/bot.py
@@ -914,7 +914,8 @@ class ModmailBot(commands.Bot):
                     description=self.config["disabled_new_thread_response"],
                 )
                 embed.set_footer(
-                    text=self.config["disabled_new_thread_footer"], icon_url=await self.bot.api.get_guild_icon()
+                    text=self.config["disabled_new_thread_footer"],
+                    icon_url=await self.bot.api.get_guild_icon(),
                 )
                 logger.info("A new thread was blocked from %s due to disabled Modmail.", message.author)
                 await self.add_reaction(message, blocked_emoji)

--- a/bot.py
+++ b/bot.py
@@ -914,7 +914,7 @@ class ModmailBot(commands.Bot):
                     description=self.config["disabled_new_thread_response"],
                 )
                 embed.set_footer(
-                    text=self.config["disabled_new_thread_footer"], icon_url=self.get_guild_icon()
+                    text=self.config["disabled_new_thread_footer"], icon_url=self.bot.api.get_guild_icon()
                 )
                 logger.info("A new thread was blocked from %s due to disabled Modmail.", message.author)
                 await self.add_reaction(message, blocked_emoji)
@@ -930,7 +930,7 @@ class ModmailBot(commands.Bot):
                 )
                 embed.set_footer(
                     text=self.config["disabled_current_thread_footer"],
-                    icon_url=self.get_guild_icon(),
+                    icon_url=self.bot.api.get_guild_icon(),
                 )
                 logger.info("A message was blocked from %s due to disabled Modmail.", message.author)
                 await self.add_reaction(message, blocked_emoji)
@@ -1337,7 +1337,7 @@ class ModmailBot(commands.Bot):
             )
             embed.set_footer(
                 text=self.config["disabled_new_thread_footer"],
-                icon_url=self.get_guild_icon(),
+                icon_url=self.bot.api.get_guild_icon(),
             )
             logger.info(
                 "A new thread using react to contact was blocked from %s due to disabled Modmail.",

--- a/bot.py
+++ b/bot.py
@@ -913,7 +913,9 @@ class ModmailBot(commands.Bot):
                     color=self.error_color,
                     description=self.config["disabled_new_thread_response"],
                 )
-                embed.set_footer(text=self.config["disabled_new_thread_footer"], icon_url=self.guild.icon.url)
+                embed.set_footer(
+                    text=self.config["disabled_new_thread_footer"], icon_url=self.get_guild_icon()
+                )
                 logger.info("A new thread was blocked from %s due to disabled Modmail.", message.author)
                 await self.add_reaction(message, blocked_emoji)
                 return await message.channel.send(embed=embed)
@@ -928,7 +930,7 @@ class ModmailBot(commands.Bot):
                 )
                 embed.set_footer(
                     text=self.config["disabled_current_thread_footer"],
-                    icon_url=self.guild.icon.url,
+                    icon_url=self.get_guild_icon(),
                 )
                 logger.info("A message was blocked from %s due to disabled Modmail.", message.author)
                 await self.add_reaction(message, blocked_emoji)
@@ -1335,7 +1337,7 @@ class ModmailBot(commands.Bot):
             )
             embed.set_footer(
                 text=self.config["disabled_new_thread_footer"],
-                icon_url=self.guild.icon.url,
+                icon_url=self.get_guild_icon(),
             )
             logger.info(
                 "A new thread using react to contact was blocked from %s due to disabled Modmail.",

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -160,7 +160,7 @@ class Modmail(commands.Cog):
                 color=self.bot.error_color, description="You dont have any snippets at the moment."
             )
             embed.set_footer(text=f'Check "{self.bot.prefix}help snippet add" to add a snippet.')
-            embed.set_author(name="Snippets", icon_url=self.bot.api.get_guild_icon())
+            embed.set_author(name="Snippets", icon_url=await self.bot.api.get_guild_icon())
             return await ctx.send(embed=embed)
 
         embeds = []
@@ -168,7 +168,7 @@ class Modmail(commands.Cog):
         for i, names in enumerate(zip_longest(*(iter(sorted(self.bot.snippets)),) * 15)):
             description = format_description(i, names)
             embed = discord.Embed(color=self.bot.main_color, description=description)
-            embed.set_author(name="Snippets", icon_url=self.bot.api.get_guild_icon())
+            embed.set_author(name="Snippets", icon_url=await self.bot.api.get_guild_icon())
             embeds.append(embed)
 
         session = EmbedPaginatorSession(ctx, *embeds)
@@ -1031,7 +1031,7 @@ class Modmail(commands.Cog):
                 name = tag
             avatar_url = self.bot.config["anon_avatar_url"]
             if avatar_url is None:
-                avatar_url = self.bot.api.get_guild_icon()
+                avatar_url = await self.bot.api.get_guild_icon()
             em.set_footer(text=name, icon_url=avatar_url)
 
             for u in users:
@@ -1120,7 +1120,7 @@ class Modmail(commands.Cog):
                 name = tag
             avatar_url = self.bot.config["anon_avatar_url"]
             if avatar_url is None:
-                avatar_url = self.bot.api.get_guild_icon()
+                avatar_url = await self.bot.api.get_guild_icon()
             em.set_footer(text=name, icon_url=avatar_url)
 
             for u in users:
@@ -1200,7 +1200,7 @@ class Modmail(commands.Cog):
         user = user if user is not None else ctx.author
 
         entries = await self.bot.api.search_closed_by(user.id)
-        embeds = self.format_log_embeds(entries, avatar_url=self.bot.api.get_guild_icon())
+        embeds = self.format_log_embeds(entries, avatar_url=await self.bot.api.get_guild_icon())
 
         if not embeds:
             embed = discord.Embed(
@@ -1250,7 +1250,7 @@ class Modmail(commands.Cog):
 
         entries = await self.bot.api.get_responded_logs(user.id)
 
-        embeds = self.format_log_embeds(entries, avatar_url=self.bot.api.get_guild_icon())
+        embeds = self.format_log_embeds(entries, avatar_url=await self.bot.api.get_guild_icon())
 
         if not embeds:
             embed = discord.Embed(
@@ -1275,7 +1275,7 @@ class Modmail(commands.Cog):
 
         entries = await self.bot.api.search_by_text(query, limit)
 
-        embeds = self.format_log_embeds(entries, avatar_url=self.bot.api.get_guild_icon())
+        embeds = self.format_log_embeds(entries, avatar_url=await self.bot.api.get_guild_icon())
 
         if not embeds:
             embed = discord.Embed(

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -160,7 +160,7 @@ class Modmail(commands.Cog):
                 color=self.bot.error_color, description="You dont have any snippets at the moment."
             )
             embed.set_footer(text=f'Check "{self.bot.prefix}help snippet add" to add a snippet.')
-            embed.set_author(name="Snippets", icon_url=self.get_guild_icon())
+            embed.set_author(name="Snippets", icon_url=self.bot.api.get_guild_icon())
             return await ctx.send(embed=embed)
 
         embeds = []
@@ -168,7 +168,7 @@ class Modmail(commands.Cog):
         for i, names in enumerate(zip_longest(*(iter(sorted(self.bot.snippets)),) * 15)):
             description = format_description(i, names)
             embed = discord.Embed(color=self.bot.main_color, description=description)
-            embed.set_author(name="Snippets", icon_url=self.get_guild_icon())
+            embed.set_author(name="Snippets", icon_url=self.bot.api.get_guild_icon())
             embeds.append(embed)
 
         session = EmbedPaginatorSession(ctx, *embeds)
@@ -1031,7 +1031,7 @@ class Modmail(commands.Cog):
                 name = tag
             avatar_url = self.bot.config["anon_avatar_url"]
             if avatar_url is None:
-                avatar_url = self.get_guild_icon()
+                avatar_url = self.bot.api.get_guild_icon()
             em.set_footer(text=name, icon_url=avatar_url)
 
             for u in users:
@@ -1120,7 +1120,7 @@ class Modmail(commands.Cog):
                 name = tag
             avatar_url = self.bot.config["anon_avatar_url"]
             if avatar_url is None:
-                avatar_url = self.get_guild_icon()
+                avatar_url = self.bot.api.get_guild_icon()
             em.set_footer(text=name, icon_url=avatar_url)
 
             for u in users:
@@ -1200,7 +1200,7 @@ class Modmail(commands.Cog):
         user = user if user is not None else ctx.author
 
         entries = await self.bot.api.search_closed_by(user.id)
-        embeds = self.format_log_embeds(entries, avatar_url=self.get_guild_icon())
+        embeds = self.format_log_embeds(entries, avatar_url=self.bot.api.get_guild_icon())
 
         if not embeds:
             embed = discord.Embed(
@@ -1250,7 +1250,7 @@ class Modmail(commands.Cog):
 
         entries = await self.bot.api.get_responded_logs(user.id)
 
-        embeds = self.format_log_embeds(entries, avatar_url=self.get_guild_icon())
+        embeds = self.format_log_embeds(entries, avatar_url=self.bot.api.get_guild_icon())
 
         if not embeds:
             embed = discord.Embed(
@@ -1275,7 +1275,7 @@ class Modmail(commands.Cog):
 
         entries = await self.bot.api.search_by_text(query, limit)
 
-        embeds = self.format_log_embeds(entries, avatar_url=self.get_guild_icon())
+        embeds = self.format_log_embeds(entries, avatar_url=self.bot.api.get_guild_icon())
 
         if not embeds:
             embed = discord.Embed(

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -160,7 +160,7 @@ class Modmail(commands.Cog):
                 color=self.bot.error_color, description="You dont have any snippets at the moment."
             )
             embed.set_footer(text=f'Check "{self.bot.prefix}help snippet add" to add a snippet.')
-            embed.set_author(name="Snippets", icon_url=ctx.guild.icon.url)
+            embed.set_author(name="Snippets", icon_url=self.get_guild_icon())
             return await ctx.send(embed=embed)
 
         embeds = []
@@ -168,7 +168,7 @@ class Modmail(commands.Cog):
         for i, names in enumerate(zip_longest(*(iter(sorted(self.bot.snippets)),) * 15)):
             description = format_description(i, names)
             embed = discord.Embed(color=self.bot.main_color, description=description)
-            embed.set_author(name="Snippets", icon_url=ctx.guild.icon.url)
+            embed.set_author(name="Snippets", icon_url=self.get_guild_icon())
             embeds.append(embed)
 
         session = EmbedPaginatorSession(ctx, *embeds)
@@ -1031,7 +1031,7 @@ class Modmail(commands.Cog):
                 name = tag
             avatar_url = self.bot.config["anon_avatar_url"]
             if avatar_url is None:
-                avatar_url = self.bot.guild.icon.url
+                avatar_url = self.get_guild_icon()
             em.set_footer(text=name, icon_url=avatar_url)
 
             for u in users:
@@ -1120,7 +1120,7 @@ class Modmail(commands.Cog):
                 name = tag
             avatar_url = self.bot.config["anon_avatar_url"]
             if avatar_url is None:
-                avatar_url = self.bot.guild.icon.url
+                avatar_url = self.get_guild_icon()
             em.set_footer(text=name, icon_url=avatar_url)
 
             for u in users:
@@ -1200,7 +1200,7 @@ class Modmail(commands.Cog):
         user = user if user is not None else ctx.author
 
         entries = await self.bot.api.search_closed_by(user.id)
-        embeds = self.format_log_embeds(entries, avatar_url=self.bot.guild.icon.url)
+        embeds = self.format_log_embeds(entries, avatar_url=self.get_guild_icon())
 
         if not embeds:
             embed = discord.Embed(
@@ -1250,7 +1250,7 @@ class Modmail(commands.Cog):
 
         entries = await self.bot.api.get_responded_logs(user.id)
 
-        embeds = self.format_log_embeds(entries, avatar_url=self.bot.guild.icon.url)
+        embeds = self.format_log_embeds(entries, avatar_url=self.get_guild_icon())
 
         if not embeds:
             embed = discord.Embed(
@@ -1275,7 +1275,7 @@ class Modmail(commands.Cog):
 
         entries = await self.bot.api.search_by_text(query, limit)
 
-        embeds = self.format_log_embeds(entries, avatar_url=self.bot.guild.icon.url)
+        embeds = self.format_log_embeds(entries, avatar_url=self.get_guild_icon())
 
         if not embeds:
             embed = discord.Embed(

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -1611,7 +1611,9 @@ class Utility(commands.Cog):
                                 for name, level in takewhile(lambda x: x is not None, items)
                             )
                             embed = discord.Embed(color=self.bot.main_color, description=description)
-                            embed.set_author(name="Permission Overrides", icon_url=await self.bot.api.get_guild_icon())
+                            embed.set_author(
+                                name="Permission Overrides", icon_url=await self.bot.api.get_guild_icon()
+                            )
                             embeds.append(embed)
 
                     session = EmbedPaginatorSession(ctx, *embeds)

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -1020,7 +1020,7 @@ class Utility(commands.Cog):
                 color=self.bot.error_color, description="You dont have any aliases at the moment."
             )
             embed.set_footer(text=f'Do "{self.bot.prefix}help alias" for more commands.')
-            embed.set_author(name="Aliases", icon_url=ctx.guild.icon.url)
+            embed.set_author(name="Aliases", icon_url=self.get_guild_icon())
             return await ctx.send(embed=embed)
 
         embeds = []
@@ -1028,7 +1028,7 @@ class Utility(commands.Cog):
         for i, names in enumerate(zip_longest(*(iter(sorted(self.bot.aliases)),) * 15)):
             description = utils.format_description(i, names)
             embed = discord.Embed(color=self.bot.main_color, description=description)
-            embed.set_author(name="Command Aliases", icon_url=ctx.guild.icon.url)
+            embed.set_author(name="Command Aliases", icon_url=self.get_guild_icon())
             embeds.append(embed)
 
         session = EmbedPaginatorSession(ctx, *embeds)
@@ -1611,7 +1611,7 @@ class Utility(commands.Cog):
                                 for name, level in takewhile(lambda x: x is not None, items)
                             )
                             embed = discord.Embed(color=self.bot.main_color, description=description)
-                            embed.set_author(name="Permission Overrides", icon_url=ctx.guild.icon.url)
+                            embed.set_author(name="Permission Overrides", icon_url=self.get_guild_icon())
                             embeds.append(embed)
 
                     session = EmbedPaginatorSession(ctx, *embeds)

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -1020,7 +1020,7 @@ class Utility(commands.Cog):
                 color=self.bot.error_color, description="You dont have any aliases at the moment."
             )
             embed.set_footer(text=f'Do "{self.bot.prefix}help alias" for more commands.')
-            embed.set_author(name="Aliases", icon_url=self.get_guild_icon())
+            embed.set_author(name="Aliases", icon_url=self.bot.api.get_guild_icon())
             return await ctx.send(embed=embed)
 
         embeds = []
@@ -1028,7 +1028,7 @@ class Utility(commands.Cog):
         for i, names in enumerate(zip_longest(*(iter(sorted(self.bot.aliases)),) * 15)):
             description = utils.format_description(i, names)
             embed = discord.Embed(color=self.bot.main_color, description=description)
-            embed.set_author(name="Command Aliases", icon_url=self.get_guild_icon())
+            embed.set_author(name="Command Aliases", icon_url=self.bot.api.get_guild_icon())
             embeds.append(embed)
 
         session = EmbedPaginatorSession(ctx, *embeds)
@@ -1611,7 +1611,7 @@ class Utility(commands.Cog):
                                 for name, level in takewhile(lambda x: x is not None, items)
                             )
                             embed = discord.Embed(color=self.bot.main_color, description=description)
-                            embed.set_author(name="Permission Overrides", icon_url=self.get_guild_icon())
+                            embed.set_author(name="Permission Overrides", icon_url=self.bot.api.get_guild_icon())
                             embeds.append(embed)
 
                     session = EmbedPaginatorSession(ctx, *embeds)

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -1020,7 +1020,7 @@ class Utility(commands.Cog):
                 color=self.bot.error_color, description="You dont have any aliases at the moment."
             )
             embed.set_footer(text=f'Do "{self.bot.prefix}help alias" for more commands.')
-            embed.set_author(name="Aliases", icon_url=self.bot.api.get_guild_icon())
+            embed.set_author(name="Aliases", icon_url=await self.bot.api.get_guild_icon())
             return await ctx.send(embed=embed)
 
         embeds = []
@@ -1028,7 +1028,7 @@ class Utility(commands.Cog):
         for i, names in enumerate(zip_longest(*(iter(sorted(self.bot.aliases)),) * 15)):
             description = utils.format_description(i, names)
             embed = discord.Embed(color=self.bot.main_color, description=description)
-            embed.set_author(name="Command Aliases", icon_url=self.bot.api.get_guild_icon())
+            embed.set_author(name="Command Aliases", icon_url=await self.bot.api.get_guild_icon())
             embeds.append(embed)
 
         session = EmbedPaginatorSession(ctx, *embeds)
@@ -1611,7 +1611,7 @@ class Utility(commands.Cog):
                                 for name, level in takewhile(lambda x: x is not None, items)
                             )
                             embed = discord.Embed(color=self.bot.main_color, description=description)
-                            embed.set_author(name="Permission Overrides", icon_url=self.bot.api.get_guild_icon())
+                            embed.set_author(name="Permission Overrides", icon_url=await self.bot.api.get_guild_icon())
                             embeds.append(embed)
 
                     session = EmbedPaginatorSession(ctx, *embeds)

--- a/core/clients.py
+++ b/core/clients.py
@@ -751,6 +751,11 @@ class MongoDBClient(ApiClient):
                 }
             }
 
+    async def get_guild_icon(self):
+        if self.bot.guild.icon.url is None:
+            return self.bot.user.display_avatar.url
+        return self.bot.guild.icon.url
+
 
 class PluginDatabaseClient:
     def __init__(self, bot):

--- a/core/clients.py
+++ b/core/clients.py
@@ -752,7 +752,7 @@ class MongoDBClient(ApiClient):
             }
 
     async def get_guild_icon(self):
-        if self.bot.guild.icon.url is None:
+        if self.bot.guild.icon is None:
             return self.bot.user.display_avatar.url
         return self.bot.guild.icon.url
 

--- a/core/thread.py
+++ b/core/thread.py
@@ -228,7 +228,7 @@ class Thread:
             else:
                 footer = self.bot.config["thread_creation_footer"]
 
-            embed.set_footer(text=footer, icon_url=self.bot.api.get_guild_icon())
+            embed.set_footer(text=footer, icon_url=await self.bot.api.get_guild_icon())
             embed.title = self.bot.config["thread_creation_title"]
 
             if creator is None or creator == recipient:
@@ -521,7 +521,7 @@ class Thread:
 
         embed.description = message
         footer = self.bot.config["thread_close_footer"]
-        embed.set_footer(text=footer, icon_url=self.bot.api.get_guild_icon())
+        embed.set_footer(text=footer, icon_url=await self.bot.api.get_guild_icon())
 
         if not silent:
             for user in self.recipients:
@@ -957,7 +957,7 @@ class Thread:
                     name = tag
                 avatar_url = self.bot.config["anon_avatar_url"]
                 if avatar_url is None:
-                    avatar_url = self.bot.api.get_guild_icon()
+                    avatar_url = await self.bot.api.get_guild_icon()
                 embed.set_author(
                     name=name,
                     icon_url=avatar_url,

--- a/core/thread.py
+++ b/core/thread.py
@@ -228,7 +228,7 @@ class Thread:
             else:
                 footer = self.bot.config["thread_creation_footer"]
 
-            embed.set_footer(text=footer, icon_url=self.bot.guild.icon.url)
+            embed.set_footer(text=footer, icon_url=self.get_guild_icon())
             embed.title = self.bot.config["thread_creation_title"]
 
             if creator is None or creator == recipient:
@@ -521,7 +521,7 @@ class Thread:
 
         embed.description = message
         footer = self.bot.config["thread_close_footer"]
-        embed.set_footer(text=footer, icon_url=self.bot.guild.icon.url)
+        embed.set_footer(text=footer, icon_url=self.get_guild_icon())
 
         if not silent:
             for user in self.recipients:
@@ -957,7 +957,7 @@ class Thread:
                     name = tag
                 avatar_url = self.bot.config["anon_avatar_url"]
                 if avatar_url is None:
-                    avatar_url = self.bot.guild.icon.url
+                    avatar_url = self.get_guild_icon()
                 embed.set_author(
                     name=name,
                     icon_url=avatar_url,

--- a/core/thread.py
+++ b/core/thread.py
@@ -228,7 +228,7 @@ class Thread:
             else:
                 footer = self.bot.config["thread_creation_footer"]
 
-            embed.set_footer(text=footer, icon_url=self.get_guild_icon())
+            embed.set_footer(text=footer, icon_url=self.bot.api.get_guild_icon())
             embed.title = self.bot.config["thread_creation_title"]
 
             if creator is None or creator == recipient:
@@ -521,7 +521,7 @@ class Thread:
 
         embed.description = message
         footer = self.bot.config["thread_close_footer"]
-        embed.set_footer(text=footer, icon_url=self.get_guild_icon())
+        embed.set_footer(text=footer, icon_url=self.bot.api.get_guild_icon())
 
         if not silent:
             for user in self.recipients:
@@ -957,7 +957,7 @@ class Thread:
                     name = tag
                 avatar_url = self.bot.config["anon_avatar_url"]
                 if avatar_url is None:
-                    avatar_url = self.get_guild_icon()
+                    avatar_url = self.bot.api.get_guild_icon()
                 embed.set_author(
                     name=name,
                     icon_url=avatar_url,


### PR DESCRIPTION
Resolves #3205 
The bot will now use the bots display avatar if it fails to find a guild icon. 

Have tested this. 

_Ignore the commits_