### PR TITLE
Fix issue where commands don't work if guild icon doesn't exist GH#3205

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9 as py
+FROM python:3.10 as py
 
 FROM py as build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10 as py
+FROM python:3.9 as py
 
 FROM py as build
 

--- a/bot.py
+++ b/bot.py
@@ -48,7 +48,7 @@ from core.models import (
 )
 from core.thread import ThreadManager
 from core.time import human_timedelta
-from core.utils import extract_block_timestamp, normalize_alias, parse_alias, truncate, tryint
+from core.utils import extract_block_timestamp, normalize_alias, parse_alias, truncate, tryint, get_guild_icon
 
 logger = getLogger(__name__)
 
@@ -913,7 +913,9 @@ class ModmailBot(commands.Bot):
                     color=self.error_color,
                     description=self.config["disabled_new_thread_response"],
                 )
-                embed.set_footer(text=self.config["disabled_new_thread_footer"], icon_url=self.guild.icon.url)
+                embed.set_footer(
+                    text=self.config["disabled_new_thread_footer"], icon_url=get_guild_icon(self.guild)
+                )
                 logger.info("A new thread was blocked from %s due to disabled Modmail.", message.author)
                 await self.add_reaction(message, blocked_emoji)
                 return await message.channel.send(embed=embed)
@@ -928,7 +930,7 @@ class ModmailBot(commands.Bot):
                 )
                 embed.set_footer(
                     text=self.config["disabled_current_thread_footer"],
-                    icon_url=self.guild.icon.url,
+                    icon_url=get_guild_icon(self.guild),
                 )
                 logger.info("A message was blocked from %s due to disabled Modmail.", message.author)
                 await self.add_reaction(message, blocked_emoji)
@@ -1335,7 +1337,7 @@ class ModmailBot(commands.Bot):
             )
             embed.set_footer(
                 text=self.config["disabled_new_thread_footer"],
-                icon_url=self.guild.icon.url,
+                icon_url=get_guild_icon(self.guild),
             )
             logger.info(
                 "A new thread using react to contact was blocked from %s due to disabled Modmail.",

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -160,7 +160,7 @@ class Modmail(commands.Cog):
                 color=self.bot.error_color, description="You dont have any snippets at the moment."
             )
             embed.set_footer(text=f'Check "{self.bot.prefix}help snippet add" to add a snippet.')
-            embed.set_author(name="Snippets", icon_url=ctx.guild.icon.url)
+            embed.set_author(name="Snippets", icon_url=get_guild_icon(ctx.guild))
             return await ctx.send(embed=embed)
 
         embeds = []
@@ -168,7 +168,7 @@ class Modmail(commands.Cog):
         for i, names in enumerate(zip_longest(*(iter(sorted(self.bot.snippets)),) * 15)):
             description = format_description(i, names)
             embed = discord.Embed(color=self.bot.main_color, description=description)
-            embed.set_author(name="Snippets", icon_url=ctx.guild.icon.url)
+            embed.set_author(name="Snippets", icon_url=get_guild_icon(ctx.guild))
             embeds.append(embed)
 
         session = EmbedPaginatorSession(ctx, *embeds)
@@ -1031,7 +1031,7 @@ class Modmail(commands.Cog):
                 name = tag
             avatar_url = self.bot.config["anon_avatar_url"]
             if avatar_url is None:
-                avatar_url = self.bot.guild.icon.url
+                avatar_url = get_guild_icon(self.bot.guild)
             em.set_footer(text=name, icon_url=avatar_url)
 
             for u in users:
@@ -1120,7 +1120,7 @@ class Modmail(commands.Cog):
                 name = tag
             avatar_url = self.bot.config["anon_avatar_url"]
             if avatar_url is None:
-                avatar_url = self.bot.guild.icon.url
+                avatar_url = get_guild_icon(self.bot.guild)
             em.set_footer(text=name, icon_url=avatar_url)
 
             for u in users:
@@ -1200,7 +1200,7 @@ class Modmail(commands.Cog):
         user = user if user is not None else ctx.author
 
         entries = await self.bot.api.search_closed_by(user.id)
-        embeds = self.format_log_embeds(entries, avatar_url=self.bot.guild.icon.url)
+        embeds = self.format_log_embeds(entries, avatar_url=get_guild_icon(self.bot.guild))
 
         if not embeds:
             embed = discord.Embed(
@@ -1250,7 +1250,7 @@ class Modmail(commands.Cog):
 
         entries = await self.bot.api.get_responded_logs(user.id)
 
-        embeds = self.format_log_embeds(entries, avatar_url=self.bot.guild.icon.url)
+        embeds = self.format_log_embeds(entries, avatar_url=get_guild_icon(self.bot.guild))
 
         if not embeds:
             embed = discord.Embed(
@@ -1275,7 +1275,7 @@ class Modmail(commands.Cog):
 
         entries = await self.bot.api.search_by_text(query, limit)
 
-        embeds = self.format_log_embeds(entries, avatar_url=self.bot.guild.icon.url)
+        embeds = self.format_log_embeds(entries, avatar_url=get_guild_icon(self.bot.guild))
 
         if not embeds:
             embed = discord.Embed(

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -30,7 +30,7 @@ from core.models import (
     UnseenFormatter,
     getLogger,
 )
-from core.utils import trigger_typing, truncate
+from core.utils import trigger_typing, truncate, get_guild_icon
 from core.paginator import EmbedPaginatorSession, MessagePaginatorSession
 
 
@@ -1020,7 +1020,7 @@ class Utility(commands.Cog):
                 color=self.bot.error_color, description="You dont have any aliases at the moment."
             )
             embed.set_footer(text=f'Do "{self.bot.prefix}help alias" for more commands.')
-            embed.set_author(name="Aliases", icon_url=ctx.guild.icon.url)
+            embed.set_author(name="Aliases", icon_url=get_guild_icon(ctx.guild))
             return await ctx.send(embed=embed)
 
         embeds = []
@@ -1028,7 +1028,7 @@ class Utility(commands.Cog):
         for i, names in enumerate(zip_longest(*(iter(sorted(self.bot.aliases)),) * 15)):
             description = utils.format_description(i, names)
             embed = discord.Embed(color=self.bot.main_color, description=description)
-            embed.set_author(name="Command Aliases", icon_url=ctx.guild.icon.url)
+            embed.set_author(name="Command Aliases", icon_url=get_guild_icon(ctx.guild))
             embeds.append(embed)
 
         session = EmbedPaginatorSession(ctx, *embeds)
@@ -1611,7 +1611,7 @@ class Utility(commands.Cog):
                                 for name, level in takewhile(lambda x: x is not None, items)
                             )
                             embed = discord.Embed(color=self.bot.main_color, description=description)
-                            embed.set_author(name="Permission Overrides", icon_url=ctx.guild.icon.url)
+                            embed.set_author(name="Permission Overrides", icon_url=get_guild_icon(ctx.guild))
                             embeds.append(embed)
 
                     session = EmbedPaginatorSession(ctx, *embeds)

--- a/core/thread.py
+++ b/core/thread.py
@@ -29,6 +29,7 @@ from core.utils import (
     get_top_role,
     create_thread_channel,
     get_joint_id,
+    get_guild_icon,
 )
 
 logger = getLogger(__name__)
@@ -228,7 +229,7 @@ class Thread:
             else:
                 footer = self.bot.config["thread_creation_footer"]
 
-            embed.set_footer(text=footer, icon_url=self.bot.guild.icon.url)
+            embed.set_footer(text=footer, icon_url=get_guild_icon(self.bot.guild))
             embed.title = self.bot.config["thread_creation_title"]
 
             if creator is None or creator == recipient:
@@ -521,7 +522,7 @@ class Thread:
 
         embed.description = message
         footer = self.bot.config["thread_close_footer"]
-        embed.set_footer(text=footer, icon_url=self.bot.guild.icon.url)
+        embed.set_footer(text=footer, icon_url=get_guild_icon(self.bot.guild))
 
         if not silent:
             for user in self.recipients:
@@ -957,7 +958,7 @@ class Thread:
                     name = tag
                 avatar_url = self.bot.config["anon_avatar_url"]
                 if avatar_url is None:
-                    avatar_url = self.bot.guild.icon.url
+                    avatar_url = get_guild_icon(self.bot.guild)
                 embed.set_author(
                     name=name,
                     icon_url=avatar_url,

--- a/core/utils.py
+++ b/core/utils.py
@@ -39,6 +39,7 @@ __all__ = [
     "get_top_role",
     "get_joint_id",
     "extract_block_timestamp",
+    "get_guild_icon",
 ]
 
 
@@ -559,3 +560,9 @@ def extract_block_timestamp(reason, id_):
             raise
 
     return end_time, after
+
+
+def get_guild_icon(self):
+    if self.bot.guild.icon.url is None:
+        return self.bot.user.display_avatar.url
+    return self.bot.guild.icon.url


### PR DESCRIPTION
Resolves #3205 
The bot will now use the bots display avatar if it fails to find a guild icon.

Ignore the dockerfile commits, I made the branch from the wrong branch. 