### PR TITLE
Add `announcement` plugin to registry.

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -8,6 +8,15 @@
         "icon_url": "https://raw.githubusercontent.com/sebkuip/mm-plugins/master/advanced-menu/logo.png",
         "thumbnail_url": "https://raw.githubusercontent.com/sebkuip/mm-plugins/master/advanced-menu/logo.png"
     },
+    "announcement": {
+        "repository": "Jerrie-Aries/modmail-plugins",
+        "branch": "master",
+        "description": "Create and post announcements. Supports both plain and embed. Also customisable using buttons and dropdown menus.",
+        "bot_version": "4.0.0",
+        "title": "Announcement",
+        "icon_url": "https://github.com/Jerrie-Aries.png",
+        "thumbnail_url": "https://raw.githubusercontent.com/Jerrie-Aries/modmail-plugins/master/.static/announcement.jpg"
+    },
     "giveaway": {
         "repository": "Jerrie-Aries/modmail-plugins",
         "branch": "master",


### PR DESCRIPTION
[Announcement](https://github.com/Jerrie-Aries/modmail-plugins/tree/master/announcement) plugin:
Create and post custom announcement.
- Supports both plain and embed.
- Customisable using buttons and dropdown menus.
