### PR TITLE
Fix error in help widget.

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -483,7 +483,7 @@ class Modmail(commands.Cog):
 
         Silently close a thread (no message)
         - `{prefix}close silently`
-        - `{prefix}close in 10m silently`
+        - `{prefix}close silently in 10m`
 
         Stop a thread from closing:
         - `{prefix}close cancel`


### PR DESCRIPTION
When using ?close in 10m silently as told in the help widget the thread won't close silently but instead closes in 10 minutes and sends the message "silently". The correct command is ?close silently in 10m.

See issue #3214 