### PR TITLE
Remove hard coded "( )" from plain messages

### DIFF
--- a/core/thread.py
+++ b/core/thread.py
@@ -1150,7 +1150,7 @@ class Thread:
                     additional_images = []
 
                 if embed.footer.text:
-                    plain_message = f"**({embed.footer.text}) "
+                    plain_message = f"**{embed.footer.text} "
                 else:
                     plain_message = "**"
                 plain_message += f"{embed.author.name}:** {embed.description}"


### PR DESCRIPTION
The "( )" dont need to be hard coded and can be added by people if they need it. 

Closes #3230 
