### PR TITLE
Optimized "blocked" command

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1665,13 +1665,7 @@ class Modmail(commands.Cog):
                     self.bot.blocked_users.pop(str(id_))
                     logger.debug("No longer blocked, user %s.", id_)
                     continue
-
-            try:
-                user = await self.bot.get_or_fetch_user(int(id_))
-            except discord.NotFound:
-                users.append((id_, reason))
-            else:
-                users.append((user.mention, reason))
+            users.append((f"<@{id_}>", reason))
 
         blocked_roles = list(self.bot.blocked_roles.items())
         for id_, reason in blocked_roles:


### PR DESCRIPTION
This fixes the issues those with large blocklists were having when attempting to use the  `blocked` command. Tested with 15k blocked user and had no performance problems (besides the memory usage going up by over 20MB).

There are some more optimizations I can make to this method that'll either end up being adding to this PR or done in the future separately depending on my time constraints.