### PR TITLE
Improve tagging of docker images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,9 +1,8 @@
-
 name: Create and publish a Docker image
 
 on:
   push:
-    branches: ['master']
+    branches: ["master"]
 
 env:
   REGISTRY: ghcr.io
@@ -32,6 +31,16 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule,pattern=nightly
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            # set latest tag for stable releases
+            type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v3


### PR DESCRIPTION
This creates a number of tags for the docker images, allowing for users to properly follow semver.

To breakdown what tags are created:'
`nightly`, ex `nightly` (if you run on schedule)
`{{version}}`, ex `4.0.0`
`{{major}}.{{minor}}`, ex `4.0`
`branch`, ex `master` (when you do on push)
Also does a tag for the git sha


See companion pr: https://github.com/modmail-dev/logviewer/pull/71