### PR TITLE
msglink command now scans all recipients

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -696,12 +696,18 @@ class Modmail(commands.Cog):
     @checks.thread_only()
     async def msglink(self, ctx, message_id: int):
         """Retrieves the link to a message in the current thread."""
-        try:
-            message = await ctx.thread.recipient.fetch_message(message_id)
-        except discord.NotFound:
+        found = False
+        for recipient in ctx.thread.recipients:
+            try:
+                message = await recipient.fetch_message(message_id)
+                found = True
+                break
+            except discord.NotFound:
+                continue
+        if not found:
             embed = discord.Embed(
-                color=self.bot.error_color, description="Message not found or no longer exists."
-            )
+                    color=self.bot.error_color, description="Message not found or no longer exists."
+                )
         else:
             embed = discord.Embed(color=self.bot.main_color, description=message.jump_url)
         await ctx.send(embed=embed)

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -706,8 +706,8 @@ class Modmail(commands.Cog):
                 continue
         if not found:
             embed = discord.Embed(
-                    color=self.bot.error_color, description="Message not found or no longer exists."
-                )
+                color=self.bot.error_color, description="Message not found or no longer exists."
+            )
         else:
             embed = discord.Embed(color=self.bot.main_color, description=message.jump_url)
         await ctx.send(embed=embed)


### PR DESCRIPTION
Previously, msglink only scanned the original recipient. This update loops over all recipients until a message is found, or returns the original error if it's not found anywhere.