### PR TITLE
Add (truncated) preview to snippets command

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -162,13 +162,12 @@ class Modmail(commands.Cog):
             embed.set_author(name="Snippets", icon_url=self.bot.get_guild_icon(guild=ctx.guild, size=128))
             return await ctx.send(embed=embed)
 
-        embeds = []
-
-        for i, names in enumerate(zip_longest(*(iter(sorted(self.bot.snippets)),) * 15)):
-            description = format_description(i, names)
-            embed = discord.Embed(color=self.bot.main_color, description=description)
+        embeds = [discord.Embed(color=self.bot.main_color) for _ in range((len(self.bot.snippets) // 10) + 1)]
+        for embed in embeds:
             embed.set_author(name="Snippets", icon_url=self.bot.get_guild_icon(guild=ctx.guild, size=128))
-            embeds.append(embed)
+
+        for i, snippet in enumerate(sorted(self.bot.snippets.items())):
+            embeds[i//10].add_field(name=snippet[0], value=return_or_truncate(snippet[1], 350), inline=False)
 
         session = EmbedPaginatorSession(ctx, *embeds)
         await session.run()

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -149,7 +149,9 @@ class Modmail(commands.Cog):
                 for i, names in enumerate(zip_longest(*(iter(sorted(self.bot.snippets)),) * 15)):
                     description = format_description(i, names)
                     embed = discord.Embed(color=self.bot.main_color, description=description)
-                    embed.set_author(name="Snippets", icon_url=self.bot.get_guild_icon(guild=ctx.guild, size=128))
+                    embed.set_author(
+                        name="Snippets", icon_url=self.bot.get_guild_icon(guild=ctx.guild, size=128)
+                    )
                     embeds.append(embed)
 
                 session = EmbedPaginatorSession(ctx, *embeds)
@@ -180,7 +182,9 @@ class Modmail(commands.Cog):
             embed.set_author(name="Snippets", icon_url=self.bot.get_guild_icon(guild=ctx.guild, size=128))
 
         for i, snippet in enumerate(sorted(self.bot.snippets.items())):
-            embeds[i//10].add_field(name=snippet[0], value=return_or_truncate(snippet[1], 350), inline=False)
+            embeds[i // 10].add_field(
+                name=snippet[0], value=return_or_truncate(snippet[1], 350), inline=False
+            )
 
         session = EmbedPaginatorSession(ctx, *embeds)
         await session.run()

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -143,6 +143,19 @@ class Modmail(commands.Cog):
         """
 
         if name is not None:
+            if name == "compact":
+                embeds = []
+
+                for i, names in enumerate(zip_longest(*(iter(sorted(self.bot.snippets)),) * 15)):
+                    description = format_description(i, names)
+                    embed = discord.Embed(color=self.bot.main_color, description=description)
+                    embed.set_author(name="Snippets", icon_url=self.bot.get_guild_icon(guild=ctx.guild, size=128))
+                    embeds.append(embed)
+
+                session = EmbedPaginatorSession(ctx, *embeds)
+                await session.run()
+                return
+
             snippet_name = self.bot._resolve_snippet(name)
 
             if snippet_name is None:

--- a/core/utils.py
+++ b/core/utils.py
@@ -579,6 +579,7 @@ def return_or_truncate(text, max_length):
         return text
     return text[: max_length - 3] + "..."
 
+
 class AcceptButton(discord.ui.Button):
     def __init__(self, emoji):
         super().__init__(style=discord.ButtonStyle.gray, emoji=emoji)

--- a/core/utils.py
+++ b/core/utils.py
@@ -39,6 +39,7 @@ __all__ = [
     "get_top_role",
     "get_joint_id",
     "extract_block_timestamp",
+    "return_or_truncate",
     "AcceptButton",
     "DenyButton",
     "ConfirmThreadCreationView",
@@ -572,6 +573,11 @@ def extract_block_timestamp(reason, id_):
 
     return end_time, after
 
+
+def return_or_truncate(text, max_length):
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 3] + "..."
 
 class AcceptButton(discord.ui.Button):
     def __init__(self, emoji):


### PR DESCRIPTION
This update changes the ?snippet command.
When the snippet command is invoked with no snippet name, but snippets do exist, it will not only show a list of all snippets, but also show a (possibly truncated to a length of 350 characters) preview.
Also changed the amount of snippets per page from 15 to 10 per page to accommodate the more space taken up.