### PR TITLE
Add support for custom activities

### DIFF
--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -499,6 +499,7 @@ class Utility(commands.Cog):
             - `listening`
             - `watching`
             - `competing`
+            - `custom`
 
         When activity type is set to `listening`,
         it must be followed by a "to": "listening to..."
@@ -509,6 +510,9 @@ class Utility(commands.Cog):
         When activity type is set to `streaming`, you can set
         the linked twitch page:
         - `{prefix}config set twitch_url https://www.twitch.tv/somechannel/`
+
+        When activity type is set to `custom`, you can set
+        any custom text as the activity message.
 
         To remove the current activity status:
         - `{prefix}activity clear`
@@ -609,7 +613,9 @@ class Utility(commands.Cog):
         elif activity_type == ActivityType.streaming:
             url = self.bot.config["twitch_url"]
 
-        if activity_type is not None:
+        if activity_type == ActivityType.custom:
+            activity = discord.CustomActivity(name=activity_message)
+        elif activity_type is not None:
             activity = discord.Activity(type=activity_type, name=activity_message, url=url)
         else:
             activity = None


### PR DESCRIPTION
This PR updates the activity logic slightly to allow for custom activities (which use the discord.Customactivity model due to slightly different field uses). Also updated the help text to reflect possible usage of the custom type.