### PR TITLE
Allow using Discord threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ however, insignificant breaking changes do not guarantee a major version bump, s
 
 # v4.1.1
 
+### Breaking
+- Modmail threads are now potentially Discord threads
+
 ### Fixed
 - `?msglink` now supports threads with multiple recipients. ([PR #3341](https://github.com/modmail-dev/Modmail/pull/3341))
 - Fixed persistent notes not working due to discord.py internal change. ([PR #3324](https://github.com/modmail-dev/Modmail/pull/3324))

--- a/bot.py
+++ b/bot.py
@@ -305,13 +305,21 @@ class ModmailBot(commands.Bot):
             logger.debug("LOG_CHANNEL_ID was invalid, removed.")
             self.config.remove("log_channel_id")
         if self.main_category is not None:
-            try:
-                channel = self.main_category.channels[0]
-                self.config["log_channel_id"] = channel.id
-                logger.warning("No log channel set, setting #%s to be the log channel.", channel.name)
-                return channel
-            except IndexError:
-                pass
+            if isinstance(self.main_category, discord.CategoryChannel):
+                try:
+                    channel = self.main_category.channels[0]
+                    self.config["log_channel_id"] = channel.id
+                    logger.warning("No log channel set, setting #%s to be the log channel.", channel.name)
+                    return channel
+                except IndexError:
+                    pass
+            elif isinstance(self.main_category, discord.TextChannel):
+                self.config["log_channel_id"] = self.main_category.id
+                logger.warning(
+                    "No log channel set, setting #%s to be the log channel.", self.main_category.name
+                )
+                return self.main_category
+
         logger.warning(
             "No log channel set, set one with `%ssetup` or `%sconfig set log_channel_id <id>`.",
             self.prefix,
@@ -419,13 +427,13 @@ class ModmailBot(commands.Bot):
         return self.modmail_guild != self.guild
 
     @property
-    def main_category(self) -> typing.Optional[discord.CategoryChannel]:
+    def main_category(self) -> typing.Optional[discord.abc.GuildChannel]:
         if self.modmail_guild is not None:
             category_id = self.config["main_category_id"]
             if category_id is not None:
                 try:
-                    cat = discord.utils.get(self.modmail_guild.categories, id=int(category_id))
-                    if cat is not None:
+                    cat = discord.utils.get(self.modmail_guild.channels, id=int(category_id))
+                    if cat is not None and isinstance(cat, (discord.CategoryChannel, discord.TextChannel)):
                         return cat
                 except ValueError:
                     pass
@@ -1351,11 +1359,12 @@ class ModmailBot(commands.Bot):
         if channel.guild != self.modmail_guild:
             return
 
+        if self.main_category == channel:
+            logger.debug("Main category was deleted.")
+            self.config.remove("main_category_id")
+            await self.config.update()
+
         if isinstance(channel, discord.CategoryChannel):
-            if self.main_category == channel:
-                logger.debug("Main category was deleted.")
-                self.config.remove("main_category_id")
-                await self.config.update()
             return
 
         if not isinstance(channel, discord.TextChannel):

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -678,6 +678,9 @@ class Modmail(commands.Cog):
     @checks.thread_only()
     async def nsfw(self, ctx):
         """Flags a Modmail thread as NSFW (not safe for work)."""
+        if isinstance(ctx.channel, discord.Thread):
+            await ctx.send("Unable to set NSFW status for Discord threads.")
+            return
         await ctx.channel.edit(nsfw=True)
         sent_emoji, _ = await self.bot.retrieve_emoji()
         await self.bot.add_reaction(ctx.message, sent_emoji)
@@ -687,6 +690,9 @@ class Modmail(commands.Cog):
     @checks.thread_only()
     async def sfw(self, ctx):
         """Flags a Modmail thread as SFW (safe for work)."""
+        if isinstance(ctx.channel, discord.Thread):
+            await ctx.send("Unable to set NSFW status for Discord threads.")
+            return
         await ctx.channel.edit(nsfw=False)
         sent_emoji, _ = await self.bot.retrieve_emoji()
         await self.bot.add_reaction(ctx.message, sent_emoji)
@@ -775,6 +781,9 @@ class Modmail(commands.Cog):
     @commands.cooldown(1, 600, BucketType.channel)
     async def title(self, ctx, *, name: str):
         """Sets title for a thread"""
+        if isinstance(ctx.channel, discord.Thread):
+            await ctx.send("Unable to set titles for Discord threads.")
+            return
         await ctx.thread.set_title(name)
         sent_emoji, _ = await self.bot.retrieve_emoji()
         await ctx.message.pin()

--- a/core/utils.py
+++ b/core/utils.py
@@ -459,7 +459,7 @@ async def create_thread_channel(bot, recipient, category, overwrites, *, name=No
     try:
         if isinstance(category, discord.TextChannel):
             # we ignore `overwrites`... maybe make private threads so it's similar?
-            channel = await category.create_thread(name=name, reason="Creating a thread channel.")
+            channel = await category.create_thread(name=name, reason="Creating a thread channel.", type=discord.ChannelType.public_thread)
         else:
             channel = await bot.modmail_guild.create_text_channel(
                 name=name,

--- a/core/utils.py
+++ b/core/utils.py
@@ -457,13 +457,17 @@ async def create_thread_channel(bot, recipient, category, overwrites, *, name=No
     errors_raised = errors_raised or []
 
     try:
-        channel = await bot.modmail_guild.create_text_channel(
-            name=name,
-            category=category,
-            overwrites=overwrites,
-            topic=f"User ID: {recipient.id}",
-            reason="Creating a thread channel.",
-        )
+        if isinstance(category, discord.TextChannel):
+            # we ignore `overwrites`... maybe make private threads so it's similar?
+            channel = await category.create_thread(name=name, reason="Creating a thread channel.")
+        else:
+            channel = await bot.modmail_guild.create_text_channel(
+                name=name,
+                category=category,
+                overwrites=overwrites,
+                topic=f"User ID: {recipient.id}",
+                reason="Creating a thread channel.",
+            )
     except discord.HTTPException as e:
         if (e.text, (category, name)) in errors_raised:
             # Just raise the error to prevent infinite recursion after retrying


### PR DESCRIPTION
Absolutely hacky support for Discord threads. There's a couple important details about Discord threads:
 - they do not support topics
 - (a bit less importantly, they can't be marked NSFW nor have overwrites)

The lack of topic support is troubling given that Modmail stuffs thread information into the channel topic. I updated some things to work based off the genesis message and -- since that does not contain the title -- disallowed setting titles for thread in Discord threads.

This can be used by setting `main_category_id` to a text channel, rather than a category channel. It worked in some basic tests I did locally, but I haven't checked in a more intensive environment.