### PR TITLE
Fix multi-guild nickname channel names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project mostly adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html);
 however, insignificant breaking changes do not guarantee a major version bump, see the reasoning [here](https://github.com/modmail-dev/modmail/issues/319). If you're a plugin developer, note the "BREAKING" section.
 
+# v4.1.3
+
+### Fixed
+- `use_nickname_channel_name` option would produce errors when the member was not found in the guild leading to the failure of opening modmail threads. ([PR #3368](https://github.com/modmail-dev/Modmail/pull/3368))
+
 # v4.1.2
 
 ### Fixed

--- a/bot.py
+++ b/bot.py
@@ -1745,7 +1745,7 @@ class ModmailBot(commands.Bot):
 
         logger.info(f"Deleted {expired_logs.deleted_count} expired logs.")
 
-        def format_channel_name(self, author, exclude_channel=None, force_null=False):
+    def format_channel_name(self, author, exclude_channel=None, force_null=False):
         """Sanitises a username for use with text channel names
 
         Placed in main bot class to be extendable to plugins"""
@@ -1757,7 +1757,7 @@ class ModmailBot(commands.Bot):
             if self.config["use_random_channel_name"]:
                 to_hash = self.token.split(".")[-1] + str(author.id)
                 digest = hashlib.md5(to_hash.encode("utf8"), usedforsecurity=False)
-                name  = digest.hexdigest()[-8:]
+                name = digest.hexdigest()[-8:]
             elif self.config["use_user_id_channel_name"]:
                 name = str(author.id)
             elif self.config["use_timestamp_channel_name"]:
@@ -1772,11 +1772,15 @@ class ModmailBot(commands.Bot):
                 else:
                     name = author.name.lower()
 
-                sanitized_name = "".join(l for l in name if l not in string.punctuation and l.isprintable()) or "null"
-                if author.discriminator != "0":
-                    sanitized_name += f"-{author.discriminator}"
+        sanitized_name = self.sanitize_name(name)
+
+        if author.discriminator != "0":
+            sanitized_name += f"-{author.discriminator}"
 
         return ensure_unique_channel_name(sanitized_name, guild, excluse_channel)
+
+    def sanitize_name(self, name: str) -> str:
+        return "".join(l for l in name if l not in string.punctuation and l.isprintable()) or "null"
 
     def ensure_unique_channel_name(self, name, guild, exclude_channel) -> str:
         counter = 1

--- a/bot.py
+++ b/bot.py
@@ -1752,7 +1752,7 @@ class ModmailBot(commands.Bot):
         guild = self.modmail_guild
 
         if force_null:
-            return "null"
+            return ensure_unique_channel_name("null", guild, excluse_channel)
         else:
             if self.config["use_random_channel_name"]:
                 to_hash = self.token.split(".")[-1] + str(author.id)
@@ -1772,11 +1772,11 @@ class ModmailBot(commands.Bot):
                 else:
                     name = author.name.lower()
 
-                name = "".join(l for l in name if l not in string.punctuation and l.isprintable()) or "null"
+                sanitized_name = "".join(l for l in name if l not in string.punctuation and l.isprintable()) or "null"
                 if author.discriminator != "0":
-                    name += f"-{author.discriminator}"
+                    sanitized_name += f"-{author.discriminator}"
 
-        return ensure_unique_channel_name(name, guild, excluse_channel)
+        return ensure_unique_channel_name(sanitized_name, guild, excluse_channel)
 
     def ensure_unique_channel_name(self, name, guild, exclude_channel) -> str:
         counter = 1

--- a/bot.py
+++ b/bot.py
@@ -1752,7 +1752,7 @@ class ModmailBot(commands.Bot):
         guild = self.modmail_guild
 
         if force_null:
-            return ensure_unique_channel_name("null", guild, excluse_channel)
+            return ensure_unique_channel_name("null", guild, exclude_channel)
         else:
             if self.config["use_random_channel_name"]:
                 to_hash = self.token.split(".")[-1] + str(author.id)
@@ -1777,7 +1777,7 @@ class ModmailBot(commands.Bot):
         if author.discriminator != "0":
             sanitized_name += f"-{author.discriminator}"
 
-        return ensure_unique_channel_name(sanitized_name, guild, excluse_channel)
+        return ensure_unique_channel_name(sanitized_name, guild, exclude_channel)
 
     def sanitize_name(self, name: str) -> str:
         return "".join(l for l in name if l not in string.punctuation and l.isprintable()) or "null"


### PR DESCRIPTION
This PR does 2 things with channel_format_name.
1. It adds a fallback in the use_nickname_channel_name option where the member wasn't gotten from the guild due to using multi-guild or not cached properly.  It will fall back to the user's display name.
2. The ensuring of unique channel names by adding a counter at the end is moved to its own function to reduce cognitive complexity.