### PR TITLE
Allow ?logs [user] to be used outside of Modmail threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project mostly adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html);
 however, insignificant breaking changes do not guarantee a major version bump, see the reasoning [here](https://github.com/modmail-dev/modmail/issues/319). If you're a plugin developer, note the "BREAKING" section.
 
+# v4.2.1
+
+### Fixed
+- `?logs [user]` can be used outside of a Modmail thread again.
+
 # v4.2.0
 
 Upgraded discord.py to version 2.6.3, added support for CV2.

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1200,7 +1200,6 @@ class Modmail(commands.Cog):
 
     @commands.group(invoke_without_command=True)
     @checks.has_permissions(PermissionLevel.SUPPORTER)
-    @checks.thread_only()
     async def logs(self, ctx, *, user: User = None):
         """
         Get previous Modmail thread logs of a member.


### PR DESCRIPTION
This PR reverts a newly introduced (and likely unintended) change preventing `?logs [user]` from being used outside of a Modmail thread.

When the logs command is used with a user argument, the current version of Modmail requires the command to be run in a Modmail thread. This behavior change appears to have been introduced with commit 9d4b8e3 as previous versions allowed the command to be used outside of Modmail threads.

The other logs commands (closed-by, delete, key, responded, search) do not require the command to be run in a thread.  These commands should all be consistent with one another.  From a usability standpoint, having to open a Modmail thread to review a user's logs (even if not intending to send the user a message) seems counterintuitive.