### PR TITLE
fix: Remove thread-only restriction from logs command

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1200,7 +1200,6 @@ class Modmail(commands.Cog):
 
     @commands.group(invoke_without_command=True)
     @checks.has_permissions(PermissionLevel.SUPPORTER)
-    @checks.thread_only()
     async def logs(self, ctx, *, user: User = None):
         """
         Get previous Modmail thread logs of a member.


### PR DESCRIPTION
The logs command can be used anywhere again.