### PR TITLE
Add threadmenu toggle notice

### DIFF
--- a/cogs/threadmenu.py
+++ b/cogs/threadmenu.py
@@ -87,6 +87,18 @@ class ThreadCreationMenuCore(commands.Cog):
         conf["enabled"] = not conf["enabled"]
         await self._save_conf(conf)
         await ctx.send(f"Thread-creation menu is now {'enabled' if conf['enabled'] else 'disabled'}.")
+        advancedmenu_plugin = self.bot.get_cog("AdvancedMenu")
+        if (
+            advancedmenu_plugin
+            and hasattr(advancedmenu_plugin, "config")
+            and advancedmenu_plugin.config.get("enabled")
+            and advancedmenu_plugin.config["enabled"] is True
+            and conf["enabled"]
+        ):
+            await ctx.send(
+                "**Warning:** You are using both the core threadmenu feature and the advancedmenu plugin.\n"
+                "It is recommended to disable/uninstall the advancedmenu plugin to avoid interruption."
+            )
 
     @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     @threadmenu.command(name="show")

--- a/cogs/threadmenu.py
+++ b/cogs/threadmenu.py
@@ -97,7 +97,8 @@ class ThreadCreationMenuCore(commands.Cog):
         ):
             await ctx.send(
                 "**Warning:** You are using both the core threadmenu feature and the advancedmenu plugin.\n"
-                "It is recommended to disable/uninstall the advancedmenu plugin to avoid interruption."
+                "It is recommended to disable/uninstall the advancedmenu plugin to avoid interruption.\n"
+                "Migration guide can be found at: <https://docs.modmail.dev/usage-guide/threadmenu#advanced-legacy-usage>"
             )
 
     @checks.has_permissions(PermissionLevel.ADMINISTRATOR)


### PR DESCRIPTION
Adds a notice to the `threadmenu toggle` command. It gets displayed if the advancedmenu plugin is part of the bot and checks if its enabled at the same time. useful for users because both would interrupt eachother.