### PR TITLE
Fixes thread_auto_close execution when disabled.

### DIFF
--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -873,6 +873,20 @@ class Utility(commands.Cog):
                 color=self.bot.main_color,
                 description=f"`{key}` had been reset to default.",
             )
+
+            # Cancel exsisting active closures from thread_auto_close due to being disabled.
+            if key == "thread_auto_close":
+                closures = self.bot.config["closures"]
+                for recipient_id, items in tuple(closures.items()):
+                    if items.get("auto_close", False) is True:
+                        self.bot.config["closures"].pop(recipient_id)
+                        await self.config.update()
+                        thread = await self.bot.threads.find(recipient_id=int(recipient_id))
+                        if thread:
+                            await thread.cancel_closure(all=True)
+                        else:
+                            self.bot.config["closures"].pop(recipient_id)
+                            await self.config.update()
         else:
             embed = discord.Embed(
                 title="Error",

--- a/core/thread.py
+++ b/core/thread.py
@@ -67,6 +67,7 @@ class Thread:
         self.wait_tasks = []
         self.close_task = None
         self.auto_close_task = None
+        self.auto_close_cancelled = False  # Track if auto-close was explicitly cancelled
         self._cancelled = False
         self._dm_menu_msg_id = None
         self._dm_menu_channel_id = None
@@ -1078,6 +1079,7 @@ class Thread:
                 self.auto_close_task = task
             else:
                 self.close_task = task
+                self.auto_close_cancelled = False  # Reset flag when manually closing
         else:
             await self._close(closer, silent, delete_channel, message)
 
@@ -1278,6 +1280,7 @@ class Thread:
         if self.auto_close_task is not None and (auto_close or all):
             self.auto_close_task.cancel()
             self.auto_close_task = None
+            self.auto_close_cancelled = True  # Mark auto-close as explicitly cancelled
 
         to_update = self.bot.config["closures"].pop(str(self.id), None)
         if to_update is not None:
@@ -1810,7 +1813,9 @@ class Thread:
             return await destination.send(embed=embed)
 
         if not note and from_mod:
-            self.bot.loop.create_task(self._restart_close_timer())  # Start or restart thread auto close
+            # Only restart auto-close if it wasn't explicitly cancelled
+            if not self.auto_close_cancelled:
+                self.bot.loop.create_task(self._restart_close_timer())  # Start or restart thread auto close
         elif not note and not from_mod:
             await self.cancel_closure(all=True)
 

--- a/core/thread.py
+++ b/core/thread.py
@@ -1811,6 +1811,8 @@ class Thread:
 
         if not note and from_mod:
             self.bot.loop.create_task(self._restart_close_timer())  # Start or restart thread auto close
+        elif not note and not from_mod:
+            await self.cancel_closure(all=True)
 
         if self.close_task is not None:
             # cancel closing if a thread message is sent.


### PR DESCRIPTION
This fixes the issue #3290 which caused threads to be auto-closed even if `thread_auto_close` has been disabled.

There was also an issue that closed the thread when the user has responded to mods. The thread should stay open and only auto close when the staff has replied back.