### PR TITLE
Update plugin URL to be the new Modmail Docs website

### DIFF
--- a/cogs/plugins.py
+++ b/cogs/plugins.py
@@ -113,7 +113,7 @@ class Plugins(commands.Cog):
     These addons could have a range of features from moderation to simply
     making your life as a moderator easier!
     Learn how to create a plugin yourself here:
-    https://github.com/modmail-dev/modmail/wiki/Plugins
+    https://docs.modmail.dev/usage-guide/plugins
     """
 
     def __init__(self, bot):


### PR DESCRIPTION
Simple edit, just making it the correct link to make it easier to find.