### PR TITLE
Plugin registry checks upon start

### DIFF
--- a/cogs/plugins.py
+++ b/cogs/plugins.py
@@ -326,15 +326,14 @@ class Plugins(commands.Cog):
             plugin = Plugin(user, repo, plugin_name, branch)
 
         else:
-            if check_registry:
-                if self.bot.config.get("registry_plugins_only"):
-                    embed = discord.Embed(
-                        description="This plugin is not in the registry. To install this plugin, "
-                        "you must set `REGISTRY_PLUGINS_ONLY=no` or remove this key in your .env file.",
-                        color=self.bot.error_color,
-                    )
-                    await ctx.send(embed=embed)
-                    return
+            if check_registry and self.bot.config.get("registry_plugins_only"):
+                embed = discord.Embed(
+                    description="This plugin is not in the registry. To install this plugin, "
+                    "you must set `REGISTRY_PLUGINS_ONLY=no` or remove this key in your .env file.",
+                    color=self.bot.error_color,
+                )
+                await ctx.send(embed=embed)
+                return
             try:
                 plugin = Plugin.from_string(plugin_name)
             except InvalidPluginError:


### PR DESCRIPTION
Plugins will be checked upon start if they are not in the registry and REGISTRY_PLUGINS_ONLY is set to Yes they will be removed. Also plugins are allowed to be removed regardless of being in the registry or not.