### PR TITLE
Replace claim plugin

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -1,13 +1,4 @@
 {
-    "advanced-menu": {
-        "repository": "sebkuip/mm-plugins",
-        "branch": "master",
-        "description": "Advanced menu plugin using dropdown selectors. Supports submenus (and sub-submenus infinitely).",
-        "bot_version": "v4.0.0",
-        "title": "Advanced menu",
-        "icon_url": "https://raw.githubusercontent.com/sebkuip/mm-plugins/master/advanced-menu/logo.png",
-        "thumbnail_url": "https://raw.githubusercontent.com/sebkuip/mm-plugins/master/advanced-menu/logo.png"
-    },
     "announcement": {
         "repository": "Jerrie-Aries/modmail-plugins",
         "branch": "master",
@@ -72,13 +63,13 @@
         "thumbnail_url": "https://i.imgur.com/Mo60CdK.png"
     },
     "claim": {
-        "repository": "fourjr/modmail-plugins",
-        "branch": "v4",
-        "description": "Allows supporters to claim thread by sending ?claim in the thread channel",
-        "bot_version": "4.0.0",
+        "repository": "martinbndr/kyb3r-modmail-plugins",
+        "branch": "master",
+        "description": "Adds claim functionality to your modmail bot.",
+        "bot_version": "4.2.1",
         "title": "Claim Thread",
-        "icon_url": "https://i.imgur.com/Mo60CdK.png",
-        "thumbnail_url": "https://i.imgur.com/Mo60CdK.png"
+        "icon_url": "https://i.ibb.co/dsPjgKLj/87249157.png",
+        "thumbnail_url": "https://i.ibb.co/dsPjgKLj/87249157.png"
     },
     "emote-manager": {
         "repository": "fourjr/modmail-plugins",


### PR DESCRIPTION
Replaces the claim plugin by fourjr to my claim plugin due to being fundamentally broken as of the current time. It has been created few support issues already that were not successfull to use the plugin.