### PR TITLE
Adds thread_cooldown for ?selfcontact

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1763,6 +1763,17 @@ class Modmail(commands.Cog):
                 await ctx.send(embed=embed, delete_after=10)
                 return
 
+        delta = await self.bot.get_thread_cooldown(ctx.message.author)
+        if delta:
+            await ctx.send(
+                embed=discord.Embed(
+                    title=self.bot.config["cooldown_thread_title"],
+                    description=self.bot.config["cooldown_thread_response"].format(delta=delta),
+                    color=self.bot.error_color,
+                )
+            )
+            return
+
         await ctx.invoke(self.contact, users=[ctx.author])
 
     @commands.command(usage="<user> [category] [options]")


### PR DESCRIPTION
Adds cooldown checking to the ?selfcontact command to enforce the `thread_cooldown` configuration for both DMing the bot and using that command.