### PR TITLE
Add `thread_creation_menu_timeout` to `duration_seconds` config group

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -240,7 +240,7 @@ class ConfigManager:
         "log_expiration",
     }
 
-    duration_seconds = {"snooze_default_duration"}
+    duration_seconds = {"snooze_default_duration", "thread_creation_menu_timeout"}
 
     booleans = {
         "use_user_id_channel_name",


### PR DESCRIPTION
This config value is not validated to be in seconds, but the threadmenu expects seconds. This PR adds this value to the `duration_seconds` config group such that it is validated, and if possible converted from other formats.
<img width="706" height="862" alt="afbeelding" src="https://github.com/user-attachments/assets/3a9fc099-cfaf-42c6-8233-d874a017005a" />

This closes #3449 